### PR TITLE
add workflow for auto-assignments in PR

### DIFF
--- a/.github/workflows/auto_assign.yml
+++ b/.github/workflows/auto_assign.yml
@@ -1,0 +1,31 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests, set to author for the PR creator
+addAssignees: author
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+# Set to team
+reviewers:
+  - /oikawa-pbl
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0
+
+# A list of assignees, overrides reviewers if set
+# assignees:
+#   - assigneeA
+
+# A number of assignees to add to the pull request
+# Set to 0 to add all of the assignees.
+# Uses numberOfReviewers if unset.
+# numberOfAssignees: 2
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it
+# skipKeywords:
+#   - wip
+
+# A list of users to be skipped by both the add reviewers and add assignees processes
+# skipUsers:
+#   - dependabot[bot]

--- a/.github/workflows/auto_assign.yml
+++ b/.github/workflows/auto_assign.yml
@@ -1,5 +1,5 @@
 # Set to true to add reviewers to pull requests
-addReviewers: true
+addReviewers: false
 
 # Set to true to add assignees to pull requests, set to author for the PR creator
 addAssignees: author


### PR DESCRIPTION
## Issue No.
N/A

## 影響範囲と理由
PR作成時、Assigneers にPR作成者が自動アサインされるようにしました。
PR作成時、Reviewers にチームにが自動アサインされるようにしました。(CODEOWNERSだけで上手くいかなかったものの、もしうまくいくようならこの箇所は削除予定)

## チェックリスト
<!-- 変更を行った際にチェックした項目にチェックを入れてください。 -->
- [ ] 単体テストを実施した
- [ ] 統合テストを実施した
- [ ] ドキュメントを更新した

## スクリーンショット
<!-- UIの変更がある場合は、Before / Afterのスクリーンショットや動作が分かるGIFなどを添付してください。 -->
N/A

## 備考
<!-- レビュワーに特に注目してほしいポイントや、不安な部分があれば明記してください。 -->

## 関連リンク
<!-- ソースコードに関連するファイルがあればリンクを共有 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - プルリクエストに自動的にレビュアーとアサインを割り当てる設定を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->