### PR TITLE
VertexAI関連のパッケージとgeminiへのリクエストコードを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,12 +125,21 @@ copilot-practice2
   FastAPI の Swagger UI から DB にアクセス可能になる。
   8000 番ポートの`/docs`パスで確認
 
+
+- Google VertexAIのローカル環境での利用方法
+  - GCPでサービスアカウントキーの作成
+  - `./backend/.env/`ディレクトリを作成して、ディレクトリ内にサービスアカウントキーを格納<br>
+    - **重要**　**ファイル名がグレーアウトされていて、GitHubに上がらないことを確認**
+  - backendのコンテナ内で`gcloud auth login --cred-file=<サービスアカウントキーのファイルのパス>`
+
+
 - パッケージを追加する場合
   - Dev Container を起動してから`$ poetry add <パッケージ>`
   - 開発環境のみのパッケージは`$ poetry add -D <パッケージ>`
     ※ローカル環境から操作したい場合
   - バックエンド `$ docker compose exec backend poetry add <パッケージ>`
   - フロントエンド `$ docker compose exec frontend poetry add <パッケージ>`
+
 
 ## 設定ファイル
 

--- a/backend/Dockerfile.backend
+++ b/backend/Dockerfile.backend
@@ -5,12 +5,21 @@ ENV PYTHONPATH=/backend
 
 WORKDIR /backend
 
+# poetryのインストール
 RUN pip install --no-cache-dir poetry==1.8.3
 
-COPY pyproject.toml* poetry.lock* /backend/
-RUN poetry config virtualenvs.in-project true && \
-    poetry install --no-root
+# 依存ファイルをコピーして依存関係をインストール
+COPY pyproject.toml poetry.lock /backend/
+RUN poetry config virtualenvs.in-project true && poetry install --no-root
 
+# gcloud SDKのインストール
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+    && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
+    && apt-get update -y \
+    && apt-get install google-cloud-sdk -y \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# アプリケーションコードをコピー
 COPY . /backend/
 
 EXPOSE 8000

--- a/backend/app/db/alembic_test/versions/5026a1da26e7_test_migration.py
+++ b/backend/app/db/alembic_test/versions/5026a1da26e7_test_migration.py
@@ -5,15 +5,12 @@ Revises: b6df2ff64f4a
 Create Date: 2024-05-28 15:53:05.552121
 
 """
+
 from typing import Sequence, Union
 
-from alembic import op
-import sqlalchemy as sa
-
-
 # revision identifiers, used by Alembic.
-revision: str = '5026a1da26e7'
-down_revision: Union[str, None] = 'b6df2ff64f4a'
+revision: str = "5026a1da26e7"
+down_revision: Union[str, None] = "b6df2ff64f4a"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.routers import files, users
+from app.routers import files, outputs, users
 
 # FastAPIのインスタンスを作成
 app = FastAPI()
@@ -9,6 +9,7 @@ app = FastAPI()
 # ルーターを登錢
 app.include_router(users.router)
 app.include_router(files.router)
+app.include_router(outputs.router)
 
 # CORSの設定
 app.add_middleware(

--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -18,7 +18,7 @@ load_dotenv()
 logging.basicConfig(level=logging.INFO)
 
 # 環境変数から認証情報を取得
-BUCKET_NAME: str = str(os.getenv("BUCKET_NAME"))
+BUCKET_NAME = str(os.getenv("BUCKET_NAME"))
 
 # ルーターの設定
 router = APIRouter(

--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -18,7 +18,7 @@ load_dotenv()
 logging.basicConfig(level=logging.INFO)
 
 # 環境変数から認証情報を取得
-BUCKET_NAME = str(os.getenv("BUCKET_NAME"))
+BUCKET_NAME: str = str(os.getenv("BUCKET_NAME"))
 
 # ルーターの設定
 router = APIRouter(

--- a/backend/app/routers/outputs.py
+++ b/backend/app/routers/outputs.py
@@ -1,0 +1,56 @@
+import logging
+
+from fastapi import APIRouter, HTTPException
+from google.api_core.exceptions import GoogleAPIError, InvalidArgument, NotFound
+
+from app.utils.gemini_request import generate_content
+
+# ロギング設定
+logging.basicConfig(level=logging.INFO)
+
+
+# ルーターの設定
+router = APIRouter(
+    prefix="/outputs",
+    tags=["outputs"],
+)
+
+
+# 複数のファイル名のリストを入力して、出力を生成するエンドポイント
+@router.post("/request", response_model=str)
+async def request_content(files: list[str]) -> str:
+    # ロギング
+    logging.info(f"Requesting content generation for files: {files}")
+
+    # ファイル名のリストを取得
+    file_names = files
+
+    try:
+        # ファイル名のリストを元に、コンテンツを生成
+        content = generate_content(file_names)
+    except NotFound as e:
+        logging.error(f"File not found in Google Cloud Storage: {e}")
+        raise HTTPException(
+            status_code=404,
+            detail="ファイルが見つかりません。ファイル名を確認してください。",
+        ) from e
+    except InvalidArgument as e:
+        logging.error(f"Invalid argument: {e}")
+        raise HTTPException(
+            status_code=400,
+            detail="ファイル名の形式が正しくありません。ファイル名を確認してください。",
+        ) from e
+    except GoogleAPIError as e:
+        logging.error(f"Google API error: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail="Google APIに関するエラーが発生しました。管理者に確認してください。",
+        ) from e
+    except Exception as e:
+        logging.error(f"Error generating content: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail="コンテンツ生成中にエラーが発生しました。管理者に確認してください。",
+        ) from e
+
+    return content

--- a/backend/app/routers/outputs.py
+++ b/backend/app/routers/outputs.py
@@ -8,7 +8,6 @@ from app.utils.gemini_request import generate_content
 # ロギング設定
 logging.basicConfig(level=logging.INFO)
 
-
 # ルーターの設定
 router = APIRouter(
     prefix="/outputs",
@@ -27,12 +26,13 @@ async def request_content(files: list[str]) -> str:
 
     try:
         # ファイル名のリストを元に、コンテンツを生成
-        content = generate_content(file_names)
+        content = await generate_content(file_names)
     except NotFound as e:
         logging.error(f"File not found in Google Cloud Storage: {e}")
         raise HTTPException(
             status_code=404,
-            detail="指定されたファイルがGoogle Cloud Storageに見つかりません。ファイル名を再確認してください。",
+            detail="指定されたファイルがGoogle Cloud Storageに見つかりません。"
+            + "ファイル名を再確認してください。",
         ) from e
     except InvalidArgument as e:
         logging.error(f"Invalid argument: {e}")
@@ -44,13 +44,15 @@ async def request_content(files: list[str]) -> str:
         logging.error(f"Google API error: {e}")
         raise HTTPException(
             status_code=500,
-            detail="Google APIからエラーが返されました。システム管理者に連絡してください。",
+            detail="Google APIからエラーが返されました。"
+            + "システム管理者に連絡してください。",
         ) from e
     except Exception as e:
         logging.error(f"Error generating content: {e}")
         raise HTTPException(
             status_code=500,
-            detail="コンテンツの生成中に予期せぬエラーが発生しました。システム管理者に連絡してください。",
+            detail="コンテンツの生成中に予期せぬエラーが発生しました。"
+            + "システム管理者に連絡してください。",
         ) from e
 
     return content

--- a/backend/app/routers/outputs.py
+++ b/backend/app/routers/outputs.py
@@ -32,25 +32,25 @@ async def request_content(files: list[str]) -> str:
         logging.error(f"File not found in Google Cloud Storage: {e}")
         raise HTTPException(
             status_code=404,
-            detail="ファイルが見つかりません。ファイル名を確認してください。",
+            detail="指定されたファイルがGoogle Cloud Storageに見つかりません。ファイル名を再確認してください。",
         ) from e
     except InvalidArgument as e:
         logging.error(f"Invalid argument: {e}")
         raise HTTPException(
             status_code=400,
-            detail="ファイル名の形式が正しくありません。ファイル名を確認してください。",
+            detail="ファイル名の形式が無効です。有効なファイル名を指定してください。",
         ) from e
     except GoogleAPIError as e:
         logging.error(f"Google API error: {e}")
         raise HTTPException(
             status_code=500,
-            detail="Google APIに関するエラーが発生しました。管理者に確認してください。",
+            detail="Google APIからエラーが返されました。システム管理者に連絡してください。",
         ) from e
     except Exception as e:
         logging.error(f"Error generating content: {e}")
         raise HTTPException(
             status_code=500,
-            detail="コンテンツ生成中にエラーが発生しました。管理者に確認してください。",
+            detail="コンテンツの生成中に予期せぬエラーが発生しました。システム管理者に連絡してください。",
         ) from e
 
     return content

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
@@ -21,8 +19,8 @@ router = APIRouter(
 
 
 # ユーザーの一覧を取得するエンドポイント
-@router.get("/", response_model=List[users_schemas.User])
-async def list_users(db: AsyncSession = db_dependency) -> List[users_schemas.User]:
+@router.get("/", response_model=list[users_schemas.User])
+async def list_users(db: AsyncSession = db_dependency) -> list[users_schemas.User]:
     return await users_cruds.get_users(db)
 
 

--- a/backend/app/utils/gemini_request.py
+++ b/backend/app/utils/gemini_request.py
@@ -1,0 +1,46 @@
+import os
+
+import vertexai
+from dotenv import load_dotenv
+from vertexai.generative_models import GenerativeModel, Part
+
+# 環境変数を読み込む
+load_dotenv()
+
+# プロジェクトIDとリージョンを環境変数から取得
+PROJECT_ID = os.getenv("PROJECT_ID")
+REGION = os.getenv("REGION")
+MODEL_NAME = "gemini-1.5-pro-001"
+
+# Vertex AIを初期化
+vertexai.init(project=PROJECT_ID, location=REGION)
+
+# PDFファイルのURI
+pdf_file_uri = "gs://ai-notebook-test001/5_アジャイルⅡ.pdf"
+
+# プロンプト（指示文）
+prompt = """
+あなたは、わかりやすく丁寧に教えることで評判の大学教授です。
+ソフトウェア工学についてのスライド資料と解説です。
+この資料と解説に基づいて、わかりやすく、親しみやすい解説がついていて、誰もが読みたくなるような整理ノートを作成して下さい。
+ビジュアル的にもわかりやすくするため、マークダウンで文字の大きさ、強調表示などのスタイルを作成して、スライド資料の図を複数挿入できるようにスライドのページと配置を指定してください。
+また、コラムや用語解説を複数つけて、興味を持てるようにしてください。
+最後に選択式と穴埋め式の練習問題を付けてください。
+問題の解答は、最後に別枠で記載してください。
+出力のファイル形式は、マークダウンのファイルで出力してください。
+"""
+
+
+# コンテンツ生成関数
+def generate_content(pdf_file_uri: str, prompt: str) -> str:
+    # モデルのインスタンスを作成
+    model = GenerativeModel(model_name=MODEL_NAME)
+    # PDFファイルのパートを作成
+    pdf_file = Part.from_uri(pdf_file_uri, mime_type="application/pdf")
+    # コンテンツリストを作成
+    contents = [pdf_file, prompt]
+    # コンテンツを生成
+    response = model.generate_content(contents)
+    # 生成されたテキストを出力
+    print(response.text)
+    return response.text

--- a/backend/app/utils/gemini_request.py
+++ b/backend/app/utils/gemini_request.py
@@ -1,8 +1,10 @@
+import logging
 import os
 
 import vertexai
 from dotenv import load_dotenv
-from vertexai.generative_models import GenerativeModel, Part
+from google.api_core.exceptions import GoogleAPIError, InvalidArgument, NotFound
+from vertexai.generative_models import GenerationConfig, GenerativeModel, Part
 
 # 環境変数を読み込む
 load_dotenv()
@@ -11,36 +13,84 @@ load_dotenv()
 PROJECT_ID = os.getenv("PROJECT_ID")
 REGION = os.getenv("REGION")
 MODEL_NAME = "gemini-1.5-pro-001"
+BUCKET_NAME = str(os.getenv("BUCKET_NAME"))
+
+# 生成モデルのパラメータを設定（JSON形式のレスポンスを指定）
+GENERATION_CONFIG = GenerationConfig(max_output_tokens=8192, temperature=0)
 
 # Vertex AIを初期化
 vertexai.init(project=PROJECT_ID, location=REGION)
 
-# PDFファイルのURI
-pdf_file_uri = "gs://ai-notebook-test001/5_アジャイルⅡ.pdf"
-
-# プロンプト（指示文）
-prompt = """
-あなたは、わかりやすく丁寧に教えることで評判の大学教授です。
-ソフトウェア工学についてのスライド資料と解説です。
-この資料と解説に基づいて、わかりやすく、親しみやすい解説がついていて、誰もが読みたくなるような整理ノートを作成して下さい。
-ビジュアル的にもわかりやすくするため、マークダウンで文字の大きさ、強調表示などのスタイルを作成して、スライド資料の図を複数挿入できるようにスライドのページと配置を指定してください。
-また、コラムや用語解説を複数つけて、興味を持てるようにしてください。
-最後に選択式と穴埋め式の練習問題を付けてください。
-問題の解答は、最後に別枠で記載してください。
-出力のファイル形式は、マークダウンのファイルで出力してください。
-"""
+# ロギングの設定
+logging.basicConfig(level=logging.INFO)
 
 
-# コンテンツ生成関数
-def generate_content(pdf_file_uri: str, prompt: str) -> str:
-    # モデルのインスタンスを作成
-    model = GenerativeModel(model_name=MODEL_NAME)
-    # PDFファイルのパートを作成
-    pdf_file = Part.from_uri(pdf_file_uri, mime_type="application/pdf")
-    # コンテンツリストを作成
-    contents = [pdf_file, prompt]
-    # コンテンツを生成
-    response = model.generate_content(contents)
-    # 生成されたテキストを出力
-    print(response.text)
+# 複数のPDFファイルを入力してコンテンツを生成
+def generate_content(
+    files: list[str],
+    model_name: str = MODEL_NAME,
+    generation_config: GenerationConfig = GENERATION_CONFIG,
+    bucket_name: str = BUCKET_NAME,
+) -> str:
+    pdf_files: list[Part] = []
+    # プロンプト（指示文）
+    prompt = """
+        - あなたは、わかりやすく丁寧に教えることで評判の大学教授です。
+        - 複数のファイルは、ソフトウェア工学について解説しているスライドです。
+        - 複数のpdfファイルを読み解いて、親しみやすい解説がついていて、
+        誰もが読みたくなるような、わかりやすい整理ノートを8000文字程度の日本語で作成して下さい。
+        - ビジュアル的にもわかりやすくするため、マークダウンで文字の大きさ、
+        強調表示などのスタイルを工夫するとともに、絵文字や図を挿入してください。
+        - コラムや用語解説のコーナーを複数設けて、興味を持てるようにしてください。
+        - 出力の形式は、「整理ノート」のみをMarkdownで出力してください。
+    """
+
+    try:
+        for file_name in files:
+            # PDFファイルのURI
+            pdf_file_uri = f"gs://{bucket_name}/{file_name}"
+            # PDFファイルのパートを作成
+            pdf_file = Part.from_uri(pdf_file_uri, mime_type="application/pdf")
+            pdf_files.append(pdf_file)
+    except NotFound as e:
+        logging.error(f"File not found: {e}")
+        raise
+    except InvalidArgument as e:
+        logging.error(f"Invalid file format: {e}")
+        raise
+    except GoogleAPIError as e:
+        logging.error(f"Google API error: {e}")
+        raise
+    except Exception as e:
+        logging.error(f"Unexpected error loading PDF files: {e}")
+        raise
+
+    try:
+        # モデルのインスタンスを作成
+        model = GenerativeModel(model_name=model_name)
+
+        # コンテンツリストを作成
+        contents = pdf_files + [prompt]
+        # モデルにプロンプトとPDFを渡してJSON形式の応答を生成
+        response = model.generate_content(contents, generation_config=generation_config)
+    except AttributeError as e:
+        logging.error(f"Model attribute error: {e}")
+        raise
+    except TypeError as e:
+        logging.error(f"Type error in model generation: {e}")
+        raise
+    except GoogleAPIError as e:
+        logging.error(f"Google API error: {e}")
+        raise
+    except Exception as e:
+        logging.error(f"Unexpected error generating content: {e}")
+        raise
+
+    logging.info(f"Response: {response.text}")
     return response.text
+
+
+# # テスト用のコード
+# if __name__ == "__main__":
+#     # コンテンツ生成関数を呼び出し
+#     generate_content(["1_ソフトウェア工学の誕生.pdf", "5_アジャイルⅡ.pdf"])

--- a/backend/app/utils/gemini_request.py
+++ b/backend/app/utils/gemini_request.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 
@@ -13,9 +14,9 @@ load_dotenv()
 PROJECT_ID = os.getenv("PROJECT_ID")
 REGION = os.getenv("REGION")
 MODEL_NAME = "gemini-1.5-pro-001"
-BUCKET_NAME = str(os.getenv("BUCKET_NAME"))
+BUCKET_NAME: str = str(os.getenv("BUCKET_NAME"))
 
-# 生成モデルのパラメータを設定（JSON形式のレスポンスを指定）
+# 生成モデルのパラメータを設定
 GENERATION_CONFIG = GenerationConfig(max_output_tokens=8192, temperature=0)
 
 # Vertex AIを初期化
@@ -26,7 +27,7 @@ logging.basicConfig(level=logging.INFO)
 
 
 # 複数のPDFファイルを入力してコンテンツを生成
-def generate_content(
+async def generate_content(
     files: list[str],
     model_name: str = MODEL_NAME,
     generation_config: GenerationConfig = GENERATION_CONFIG,
@@ -35,14 +36,16 @@ def generate_content(
     pdf_files: list[Part] = []
     # プロンプト（指示文）
     prompt = """
-        - あなたは、わかりやすく丁寧に教えることで評判の大学教授です。
-        - 複数のファイルは、ソフトウェア工学について解説しているスライドです。
-        - 複数のpdfファイルを読み解いて、親しみやすい解説がついていて、
-        誰もが読みたくなるような、わかりやすい整理ノートを8000文字程度の日本語で作成して下さい。
-        - ビジュアル的にもわかりやすくするため、マークダウンで文字の大きさ、
-        強調表示などのスタイルを工夫するとともに、絵文字や図を挿入してください。
-        - コラムや用語解説のコーナーを複数設けて、興味を持てるようにしてください。
-        - 出力の形式は、「整理ノート」のみをMarkdownで出力してください。
+        - #role: あなたは、わかりやすく丁寧に教えることで評判の大学の「AI教授」です。
+        - #input_files: 複数のファイルは、ソフトウェア工学の解説スライドです。
+        - #instruction: 複数のpdfファイルを読み解いて、親しみやすい解説がついていて、
+            誰もが読みたくなるような、わかりやすい整理ノートを日本語で作成して下さい。
+        - #style: ビジュアル的にもわかりやすくするため、マークダウンで文字の大きさ、
+            強調表示などのスタイルを工夫してください。
+        - #condition1: 絵文字を使って、視覚的にもわかりやすくしてください。
+        - #condition2: 途中に興味深いコラムを設けてください。
+        - #condition3: 最後に用語解説のコーナーを設けてください。
+        - #format: タイトルを付けて、8000文字程度のMarkdownで出力してください。
     """
 
     try:
@@ -53,16 +56,16 @@ def generate_content(
             pdf_file = Part.from_uri(pdf_file_uri, mime_type="application/pdf")
             pdf_files.append(pdf_file)
     except NotFound as e:
-        logging.error(f"指定されたファイルが見つかりません: {e}")
+        logging.error(f"File not found: {e}")
         raise
     except InvalidArgument as e:
-        logging.error(f"ファイル形式が無効です: {e}")
+        logging.error(f"Invalid file format: {e}")
         raise
     except GoogleAPIError as e:
-        logging.error(f"Google APIからのエラーが発生しました: {e}")
+        logging.error(f"Google API error: {e}")
         raise
     except Exception as e:
-        logging.error(f"PDFファイルの読み込み中に予期せぬエラーが発生しました: {e}")
+        logging.error(f"Unexpected error while reading PDF files: {e}")
         raise
 
     try:
@@ -71,8 +74,11 @@ def generate_content(
 
         # コンテンツリストを作成
         contents = pdf_files + [prompt]
-        # モデルにプロンプトとPDFを渡してJSON形式の応答を生成
-        response = model.generate_content(contents, generation_config=generation_config)
+
+        # 非同期でモデルにプロンプトとPDFを渡して応答を生成
+        response = await asyncio.to_thread(
+            model.generate_content, contents, generation_config=generation_config
+        )
     except AttributeError as e:
         logging.error(f"Model attribute error: {e}")
         raise
@@ -80,10 +86,10 @@ def generate_content(
         logging.error(f"Type error in model generation: {e}")
         raise
     except GoogleAPIError as e:
-        logging.error(f"Google APIからのエラーが発生しました: {e}")
+        logging.error(f"Google API error: {e}")
         raise
     except Exception as e:
-        logging.error(f"コンテンツ生成中に予期せぬエラーが発生しました: {e}")
+        logging.error(f"Unexpected error during content generation: {e}")
         raise
 
     logging.info(f"Response: {response.text}")
@@ -91,6 +97,9 @@ def generate_content(
 
 
 # # テスト用のコード
+# async def main() -> None:
+#     await generate_content(["1_ソフトウェア工学の誕生.pdf", "5_アジャイルⅡ.pdf"])
+
+
 # if __name__ == "__main__":
-#     # コンテンツ生成関数を呼び出し
-#     generate_content(["1_ソフトウェア工学の誕生.pdf", "5_アジャイルⅡ.pdf"])
+#     asyncio.run(main())

--- a/backend/app/utils/gemini_request.py
+++ b/backend/app/utils/gemini_request.py
@@ -53,16 +53,16 @@ def generate_content(
             pdf_file = Part.from_uri(pdf_file_uri, mime_type="application/pdf")
             pdf_files.append(pdf_file)
     except NotFound as e:
-        logging.error(f"File not found: {e}")
+        logging.error(f"指定されたファイルが見つかりません: {e}")
         raise
     except InvalidArgument as e:
-        logging.error(f"Invalid file format: {e}")
+        logging.error(f"ファイル形式が無効です: {e}")
         raise
     except GoogleAPIError as e:
-        logging.error(f"Google API error: {e}")
+        logging.error(f"Google APIからのエラーが発生しました: {e}")
         raise
     except Exception as e:
-        logging.error(f"Unexpected error loading PDF files: {e}")
+        logging.error(f"PDFファイルの読み込み中に予期せぬエラーが発生しました: {e}")
         raise
 
     try:
@@ -80,10 +80,10 @@ def generate_content(
         logging.error(f"Type error in model generation: {e}")
         raise
     except GoogleAPIError as e:
-        logging.error(f"Google API error: {e}")
+        logging.error(f"Google APIからのエラーが発生しました: {e}")
         raise
     except Exception as e:
-        logging.error(f"Unexpected error generating content: {e}")
+        logging.error(f"コンテンツ生成中に予期せぬエラーが発生しました: {e}")
         raise
 
     logging.info(f"Response: {response.text}")

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -408,6 +408,17 @@ test = ["certifi", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-co
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
+name = "docstring-parser"
+version = "0.16"
+description = "Parse Python docstrings in reST, Google and Numpydoc format"
+optional = false
+python-versions = ">=3.6,<4.0"
+files = [
+    {file = "docstring_parser-0.16-py3-none-any.whl", hash = "sha256:bf0a1387354d3691d102edef7ec124f219ef639982d096e26e3b60aeffa90637"},
+    {file = "docstring_parser-0.16.tar.gz", hash = "sha256:538beabd0af1e2db0146b6bd3caa526c35a34d61af9fd2887f3a8a27a739aa6e"},
+]
+
+[[package]]
 name = "fastapi"
 version = "0.110.2"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
@@ -440,6 +451,8 @@ files = [
 [package.dependencies]
 google-auth = ">=2.14.1,<3.0.dev0"
 googleapis-common-protos = ">=1.56.2,<2.0.dev0"
+grpcio = {version = ">=1.49.1,<2.0dev", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""}
+grpcio-status = {version = ">=1.49.1,<2.0.dev0", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""}
 proto-plus = ">=1.22.3,<2.0.0dev"
 protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0.dev0"
 requests = ">=2.18.0,<3.0.0.dev0"
@@ -473,6 +486,84 @@ reauth = ["pyu2f (>=0.1.5)"]
 requests = ["requests (>=2.20.0,<3.0.0.dev0)"]
 
 [[package]]
+name = "google-cloud-aiplatform"
+version = "1.53.0"
+description = "Vertex AI API client library"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "google-cloud-aiplatform-1.53.0.tar.gz", hash = "sha256:574cfad8ac5fa5d57ef717f5335ce05636a5fa9b8aeea0f5c325b46b9448e6b1"},
+    {file = "google_cloud_aiplatform-1.53.0-py2.py3-none-any.whl", hash = "sha256:9dfb1f110e6d4795b45afcfab79108fc5c8ed9aa4eaf899e433bc2ca1b76c778"},
+]
+
+[package.dependencies]
+docstring-parser = "<1"
+google-api-core = {version = ">=1.34.1,<2.0.dev0 || >=2.8.dev0,<3.0.0dev", extras = ["grpc"]}
+google-auth = ">=2.14.1,<3.0.0dev"
+google-cloud-bigquery = ">=1.15.0,<3.20.0 || >3.20.0,<4.0.0dev"
+google-cloud-resource-manager = ">=1.3.3,<3.0.0dev"
+google-cloud-storage = ">=1.32.0,<3.0.0dev"
+packaging = ">=14.3"
+proto-plus = ">=1.22.0,<2.0.0dev"
+protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0dev"
+pydantic = "<3"
+shapely = "<3.0.0dev"
+
+[package.extras]
+autologging = ["mlflow (>=1.27.0,<=2.1.1)"]
+cloud-profiler = ["tensorboard-plugin-profile (>=2.4.0,<3.0.0dev)", "tensorflow (>=2.4.0,<3.0.0dev)", "werkzeug (>=2.0.0,<2.1.0dev)"]
+datasets = ["pyarrow (>=10.0.1)", "pyarrow (>=14.0.0)", "pyarrow (>=3.0.0,<8.0dev)"]
+endpoint = ["requests (>=2.28.1)"]
+full = ["cloudpickle (<3.0)", "docker (>=5.0.3)", "explainable-ai-sdk (>=1.0.0)", "fastapi (>=0.71.0,<=0.109.1)", "google-cloud-bigquery", "google-cloud-bigquery-storage", "google-cloud-logging (<4.0)", "google-vizier (>=0.1.6)", "httpx (>=0.23.0,<0.25.0)", "immutabledict", "lit-nlp (==0.4.0)", "mlflow (>=1.27.0,<=2.1.1)", "nest-asyncio (>=1.0.0,<1.6.0)", "numpy (>=1.15.0)", "pandas (>=1.0.0)", "pandas (>=1.0.0,<2.2.0)", "pyarrow (>=10.0.1)", "pyarrow (>=14.0.0)", "pyarrow (>=3.0.0,<8.0dev)", "pyarrow (>=6.0.1)", "pydantic (<2)", "pyyaml (>=5.3.1,<7)", "ray[default] (>=2.4,<2.5.dev0 || >2.9.0,!=2.9.1,!=2.9.2,<=2.9.3)", "ray[default] (>=2.5,<=2.9.3)", "requests (>=2.28.1)", "starlette (>=0.17.1)", "tensorflow (>=2.3.0,<3.0.0dev)", "tensorflow (>=2.3.0,<3.0.0dev)", "urllib3 (>=1.21.1,<1.27)", "uvicorn[standard] (>=0.16.0)"]
+langchain = ["langchain (>=0.1.16,<0.2)", "langchain-core (<0.2)", "langchain-google-vertexai (<2)"]
+langchain-testing = ["absl-py", "cloudpickle (>=2.2.1,<4.0)", "langchain (>=0.1.16,<0.2)", "langchain-core (<0.2)", "langchain-google-vertexai (<2)", "pydantic (>=2.6.3,<3)", "pytest-xdist"]
+lit = ["explainable-ai-sdk (>=1.0.0)", "lit-nlp (==0.4.0)", "pandas (>=1.0.0)", "tensorflow (>=2.3.0,<3.0.0dev)"]
+metadata = ["numpy (>=1.15.0)", "pandas (>=1.0.0)"]
+pipelines = ["pyyaml (>=5.3.1,<7)"]
+prediction = ["docker (>=5.0.3)", "fastapi (>=0.71.0,<=0.109.1)", "httpx (>=0.23.0,<0.25.0)", "starlette (>=0.17.1)", "uvicorn[standard] (>=0.16.0)"]
+preview = ["cloudpickle (<3.0)", "google-cloud-logging (<4.0)"]
+private-endpoints = ["requests (>=2.28.1)", "urllib3 (>=1.21.1,<1.27)"]
+rapid-evaluation = ["nest-asyncio (>=1.0.0,<1.6.0)", "pandas (>=1.0.0,<2.2.0)"]
+ray = ["google-cloud-bigquery", "google-cloud-bigquery-storage", "immutabledict", "pandas (>=1.0.0,<2.2.0)", "pyarrow (>=6.0.1)", "pydantic (<2)", "ray[default] (>=2.4,<2.5.dev0 || >2.9.0,!=2.9.1,!=2.9.2,<=2.9.3)", "ray[default] (>=2.5,<=2.9.3)"]
+ray-testing = ["google-cloud-bigquery", "google-cloud-bigquery-storage", "immutabledict", "pandas (>=1.0.0,<2.2.0)", "pyarrow (>=6.0.1)", "pydantic (<2)", "pytest-xdist", "ray[default] (>=2.4,<2.5.dev0 || >2.9.0,!=2.9.1,!=2.9.2,<=2.9.3)", "ray[default] (>=2.5,<=2.9.3)", "ray[train] (>=2.4,<2.5.dev0 || >2.9.0,!=2.9.1,!=2.9.2,<=2.9.3)", "scikit-learn", "tensorflow", "torch (>=2.0.0,<2.1.0)", "xgboost", "xgboost-ray"]
+reasoningengine = ["cloudpickle (>=2.2.1,<4.0)", "pydantic (>=2.6.3,<3)"]
+tensorboard = ["tensorflow (>=2.3.0,<3.0.0dev)"]
+testing = ["bigframes", "cloudpickle (<3.0)", "docker (>=5.0.3)", "explainable-ai-sdk (>=1.0.0)", "fastapi (>=0.71.0,<=0.109.1)", "google-api-core (>=2.11,<3.0.0)", "google-cloud-bigquery", "google-cloud-bigquery-storage", "google-cloud-logging (<4.0)", "google-vizier (>=0.1.6)", "grpcio-testing", "httpx (>=0.23.0,<0.25.0)", "immutabledict", "ipython", "kfp (>=2.6.0,<3.0.0)", "lit-nlp (==0.4.0)", "mlflow (>=1.27.0,<=2.1.1)", "nest-asyncio (>=1.0.0,<1.6.0)", "numpy (>=1.15.0)", "pandas (>=1.0.0)", "pandas (>=1.0.0,<2.2.0)", "pyarrow (>=10.0.1)", "pyarrow (>=14.0.0)", "pyarrow (>=3.0.0,<8.0dev)", "pyarrow (>=6.0.1)", "pydantic (<2)", "pyfakefs", "pytest-asyncio", "pytest-xdist", "pyyaml (>=5.3.1,<7)", "ray[default] (>=2.4,<2.5.dev0 || >2.9.0,!=2.9.1,!=2.9.2,<=2.9.3)", "ray[default] (>=2.5,<=2.9.3)", "requests (>=2.28.1)", "requests-toolbelt (<1.0.0)", "scikit-learn", "starlette (>=0.17.1)", "tensorboard-plugin-profile (>=2.4.0,<3.0.0dev)", "tensorflow (==2.13.0)", "tensorflow (==2.16.1)", "tensorflow (>=2.3.0,<3.0.0dev)", "tensorflow (>=2.3.0,<3.0.0dev)", "tensorflow (>=2.4.0,<3.0.0dev)", "torch (>=2.0.0,<2.1.0)", "torch (>=2.2.0)", "urllib3 (>=1.21.1,<1.27)", "uvicorn[standard] (>=0.16.0)", "werkzeug (>=2.0.0,<2.1.0dev)", "xgboost"]
+vizier = ["google-vizier (>=0.1.6)"]
+xai = ["tensorflow (>=2.3.0,<3.0.0dev)"]
+
+[[package]]
+name = "google-cloud-bigquery"
+version = "3.24.0"
+description = "Google BigQuery API client library"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "google-cloud-bigquery-3.24.0.tar.gz", hash = "sha256:e95e6f6e0aa32e6c453d44e2b3298931fdd7947c309ea329a31b6ff1f939e17e"},
+    {file = "google_cloud_bigquery-3.24.0-py2.py3-none-any.whl", hash = "sha256:bc08323ce99dee4e811b7c3d0cde8929f5bf0b1aeaed6bcd75fc89796dd87652"},
+]
+
+[package.dependencies]
+google-api-core = {version = ">=1.34.1,<2.0.dev0 || >=2.11.dev0,<3.0.0dev", extras = ["grpc"]}
+google-auth = ">=2.14.1,<3.0.0dev"
+google-cloud-core = ">=1.6.0,<3.0.0dev"
+google-resumable-media = ">=0.6.0,<3.0dev"
+packaging = ">=20.0.0"
+python-dateutil = ">=2.7.2,<3.0dev"
+requests = ">=2.21.0,<3.0.0dev"
+
+[package.extras]
+all = ["Shapely (>=1.8.4,<3.0.0dev)", "db-dtypes (>=0.3.0,<2.0.0dev)", "geopandas (>=0.9.0,<1.0dev)", "google-cloud-bigquery-storage (>=2.6.0,<3.0.0dev)", "grpcio (>=1.47.0,<2.0dev)", "grpcio (>=1.49.1,<2.0dev)", "importlib-metadata (>=1.0.0)", "ipykernel (>=6.0.0)", "ipython (>=7.23.1,!=8.1.0)", "ipywidgets (>=7.7.0)", "opentelemetry-api (>=1.1.0)", "opentelemetry-instrumentation (>=0.20b0)", "opentelemetry-sdk (>=1.1.0)", "pandas (>=1.1.0)", "proto-plus (>=1.15.0,<2.0.0dev)", "protobuf (>=3.19.5,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev)", "pyarrow (>=3.0.0)", "tqdm (>=4.7.4,<5.0.0dev)"]
+bigquery-v2 = ["proto-plus (>=1.15.0,<2.0.0dev)", "protobuf (>=3.19.5,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev)"]
+bqstorage = ["google-cloud-bigquery-storage (>=2.6.0,<3.0.0dev)", "grpcio (>=1.47.0,<2.0dev)", "grpcio (>=1.49.1,<2.0dev)", "pyarrow (>=3.0.0)"]
+geopandas = ["Shapely (>=1.8.4,<3.0.0dev)", "geopandas (>=0.9.0,<1.0dev)"]
+ipython = ["ipykernel (>=6.0.0)", "ipython (>=7.23.1,!=8.1.0)"]
+ipywidgets = ["ipykernel (>=6.0.0)", "ipywidgets (>=7.7.0)"]
+opentelemetry = ["opentelemetry-api (>=1.1.0)", "opentelemetry-instrumentation (>=0.20b0)", "opentelemetry-sdk (>=1.1.0)"]
+pandas = ["db-dtypes (>=0.3.0,<2.0.0dev)", "importlib-metadata (>=1.0.0)", "pandas (>=1.1.0)", "pyarrow (>=3.0.0)"]
+tqdm = ["tqdm (>=4.7.4,<5.0.0dev)"]
+
+[[package]]
 name = "google-cloud-core"
 version = "2.4.1"
 description = "Google Cloud API client core library"
@@ -489,6 +580,24 @@ google-auth = ">=1.25.0,<3.0dev"
 
 [package.extras]
 grpc = ["grpcio (>=1.38.0,<2.0dev)", "grpcio-status (>=1.38.0,<2.0.dev0)"]
+
+[[package]]
+name = "google-cloud-resource-manager"
+version = "1.12.3"
+description = "Google Cloud Resource Manager API client library"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "google-cloud-resource-manager-1.12.3.tar.gz", hash = "sha256:809851824119834e4f2310b2c4f38621c1d16b2bb14d5b9f132e69c79d355e7f"},
+    {file = "google_cloud_resource_manager-1.12.3-py2.py3-none-any.whl", hash = "sha256:92be7d6959927b76d90eafc4028985c37975a46ded5466a018f02e8649e113d4"},
+]
+
+[package.dependencies]
+google-api-core = {version = ">=1.34.1,<2.0.dev0 || >=2.11.dev0,<3.0.0dev", extras = ["grpc"]}
+google-auth = ">=2.14.1,<2.24.0 || >2.24.0,<2.25.0 || >2.25.0,<3.0.0dev"
+grpc-google-iam-v1 = ">=0.12.4,<1.0.0dev"
+proto-plus = ">=1.22.3,<2.0.0dev"
+protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0dev"
 
 [[package]]
 name = "google-cloud-storage"
@@ -622,6 +731,7 @@ files = [
 ]
 
 [package.dependencies]
+grpcio = {version = ">=1.44.0,<2.0.0.dev0", optional = true, markers = "extra == \"grpc\""}
 protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0.dev0"
 
 [package.extras]
@@ -697,6 +807,96 @@ files = [
 [package.extras]
 docs = ["Sphinx", "furo"]
 test = ["objgraph", "psutil"]
+
+[[package]]
+name = "grpc-google-iam-v1"
+version = "0.13.0"
+description = "IAM API client library"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "grpc-google-iam-v1-0.13.0.tar.gz", hash = "sha256:fad318608b9e093258fbf12529180f400d1c44453698a33509cc6ecf005b294e"},
+    {file = "grpc_google_iam_v1-0.13.0-py2.py3-none-any.whl", hash = "sha256:53902e2af7de8df8c1bd91373d9be55b0743ec267a7428ea638db3775becae89"},
+]
+
+[package.dependencies]
+googleapis-common-protos = {version = ">=1.56.0,<2.0.0dev", extras = ["grpc"]}
+grpcio = ">=1.44.0,<2.0.0dev"
+protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0dev"
+
+[[package]]
+name = "grpcio"
+version = "1.64.1"
+description = "HTTP/2-based RPC framework"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "grpcio-1.64.1-cp310-cp310-linux_armv7l.whl", hash = "sha256:55697ecec192bc3f2f3cc13a295ab670f51de29884ca9ae6cd6247df55df2502"},
+    {file = "grpcio-1.64.1-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:3b64ae304c175671efdaa7ec9ae2cc36996b681eb63ca39c464958396697daff"},
+    {file = "grpcio-1.64.1-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:bac71b4b28bc9af61efcdc7630b166440bbfbaa80940c9a697271b5e1dabbc61"},
+    {file = "grpcio-1.64.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6c024ffc22d6dc59000faf8ad781696d81e8e38f4078cb0f2630b4a3cf231a90"},
+    {file = "grpcio-1.64.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e7cd5c1325f6808b8ae31657d281aadb2a51ac11ab081ae335f4f7fc44c1721d"},
+    {file = "grpcio-1.64.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:0a2813093ddb27418a4c99f9b1c223fab0b053157176a64cc9db0f4557b69bd9"},
+    {file = "grpcio-1.64.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2981c7365a9353f9b5c864595c510c983251b1ab403e05b1ccc70a3d9541a73b"},
+    {file = "grpcio-1.64.1-cp310-cp310-win32.whl", hash = "sha256:1262402af5a511c245c3ae918167eca57342c72320dffae5d9b51840c4b2f86d"},
+    {file = "grpcio-1.64.1-cp310-cp310-win_amd64.whl", hash = "sha256:19264fc964576ddb065368cae953f8d0514ecc6cb3da8903766d9fb9d4554c33"},
+    {file = "grpcio-1.64.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:58b1041e7c870bb30ee41d3090cbd6f0851f30ae4eb68228955d973d3efa2e61"},
+    {file = "grpcio-1.64.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:bbc5b1d78a7822b0a84c6f8917faa986c1a744e65d762ef6d8be9d75677af2ca"},
+    {file = "grpcio-1.64.1-cp311-cp311-manylinux_2_17_aarch64.whl", hash = "sha256:5841dd1f284bd1b3d8a6eca3a7f062b06f1eec09b184397e1d1d43447e89a7ae"},
+    {file = "grpcio-1.64.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8caee47e970b92b3dd948371230fcceb80d3f2277b3bf7fbd7c0564e7d39068e"},
+    {file = "grpcio-1.64.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:73819689c169417a4f978e562d24f2def2be75739c4bed1992435d007819da1b"},
+    {file = "grpcio-1.64.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:6503b64c8b2dfad299749cad1b595c650c91e5b2c8a1b775380fcf8d2cbba1e9"},
+    {file = "grpcio-1.64.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:1de403fc1305fd96cfa75e83be3dee8538f2413a6b1685b8452301c7ba33c294"},
+    {file = "grpcio-1.64.1-cp311-cp311-win32.whl", hash = "sha256:d4d29cc612e1332237877dfa7fe687157973aab1d63bd0f84cf06692f04c0367"},
+    {file = "grpcio-1.64.1-cp311-cp311-win_amd64.whl", hash = "sha256:5e56462b05a6f860b72f0fa50dca06d5b26543a4e88d0396259a07dc30f4e5aa"},
+    {file = "grpcio-1.64.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:4657d24c8063e6095f850b68f2d1ba3b39f2b287a38242dcabc166453e950c59"},
+    {file = "grpcio-1.64.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:62b4e6eb7bf901719fce0ca83e3ed474ae5022bb3827b0a501e056458c51c0a1"},
+    {file = "grpcio-1.64.1-cp312-cp312-manylinux_2_17_aarch64.whl", hash = "sha256:ee73a2f5ca4ba44fa33b4d7d2c71e2c8a9e9f78d53f6507ad68e7d2ad5f64a22"},
+    {file = "grpcio-1.64.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:198908f9b22e2672a998870355e226a725aeab327ac4e6ff3a1399792ece4762"},
+    {file = "grpcio-1.64.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39b9d0acaa8d835a6566c640f48b50054f422d03e77e49716d4c4e8e279665a1"},
+    {file = "grpcio-1.64.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:5e42634a989c3aa6049f132266faf6b949ec2a6f7d302dbb5c15395b77d757eb"},
+    {file = "grpcio-1.64.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:b1a82e0b9b3022799c336e1fc0f6210adc019ae84efb7321d668129d28ee1efb"},
+    {file = "grpcio-1.64.1-cp312-cp312-win32.whl", hash = "sha256:55260032b95c49bee69a423c2f5365baa9369d2f7d233e933564d8a47b893027"},
+    {file = "grpcio-1.64.1-cp312-cp312-win_amd64.whl", hash = "sha256:c1a786ac592b47573a5bb7e35665c08064a5d77ab88a076eec11f8ae86b3e3f6"},
+    {file = "grpcio-1.64.1-cp38-cp38-linux_armv7l.whl", hash = "sha256:a011ac6c03cfe162ff2b727bcb530567826cec85eb8d4ad2bfb4bd023287a52d"},
+    {file = "grpcio-1.64.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:4d6dab6124225496010bd22690f2d9bd35c7cbb267b3f14e7a3eb05c911325d4"},
+    {file = "grpcio-1.64.1-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:a5e771d0252e871ce194d0fdcafd13971f1aae0ddacc5f25615030d5df55c3a2"},
+    {file = "grpcio-1.64.1-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2c3c1b90ab93fed424e454e93c0ed0b9d552bdf1b0929712b094f5ecfe7a23ad"},
+    {file = "grpcio-1.64.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:20405cb8b13fd779135df23fabadc53b86522d0f1cba8cca0e87968587f50650"},
+    {file = "grpcio-1.64.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:0cc79c982ccb2feec8aad0e8fb0d168bcbca85bc77b080d0d3c5f2f15c24ea8f"},
+    {file = "grpcio-1.64.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:a3a035c37ce7565b8f4f35ff683a4db34d24e53dc487e47438e434eb3f701b2a"},
+    {file = "grpcio-1.64.1-cp38-cp38-win32.whl", hash = "sha256:1257b76748612aca0f89beec7fa0615727fd6f2a1ad580a9638816a4b2eb18fd"},
+    {file = "grpcio-1.64.1-cp38-cp38-win_amd64.whl", hash = "sha256:0a12ddb1678ebc6a84ec6b0487feac020ee2b1659cbe69b80f06dbffdb249122"},
+    {file = "grpcio-1.64.1-cp39-cp39-linux_armv7l.whl", hash = "sha256:75dbbf415026d2862192fe1b28d71f209e2fd87079d98470db90bebe57b33179"},
+    {file = "grpcio-1.64.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e3d9f8d1221baa0ced7ec7322a981e28deb23749c76eeeb3d33e18b72935ab62"},
+    {file = "grpcio-1.64.1-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:5f8b75f64d5d324c565b263c67dbe4f0af595635bbdd93bb1a88189fc62ed2e5"},
+    {file = "grpcio-1.64.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c84ad903d0d94311a2b7eea608da163dace97c5fe9412ea311e72c3684925602"},
+    {file = "grpcio-1.64.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:940e3ec884520155f68a3b712d045e077d61c520a195d1a5932c531f11883489"},
+    {file = "grpcio-1.64.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:f10193c69fc9d3d726e83bbf0f3d316f1847c3071c8c93d8090cf5f326b14309"},
+    {file = "grpcio-1.64.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ac15b6c2c80a4d1338b04d42a02d376a53395ddf0ec9ab157cbaf44191f3ffdd"},
+    {file = "grpcio-1.64.1-cp39-cp39-win32.whl", hash = "sha256:03b43d0ccf99c557ec671c7dede64f023c7da9bb632ac65dbc57f166e4970040"},
+    {file = "grpcio-1.64.1-cp39-cp39-win_amd64.whl", hash = "sha256:ed6091fa0adcc7e4ff944090cf203a52da35c37a130efa564ded02b7aff63bcd"},
+    {file = "grpcio-1.64.1.tar.gz", hash = "sha256:8d51dd1c59d5fa0f34266b80a3805ec29a1f26425c2a54736133f6d87fc4968a"},
+]
+
+[package.extras]
+protobuf = ["grpcio-tools (>=1.64.1)"]
+
+[[package]]
+name = "grpcio-status"
+version = "1.62.2"
+description = "Status proto mapping for gRPC"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "grpcio-status-1.62.2.tar.gz", hash = "sha256:62e1bfcb02025a1cd73732a2d33672d3e9d0df4d21c12c51e0bbcaf09bab742a"},
+    {file = "grpcio_status-1.62.2-py3-none-any.whl", hash = "sha256:206ddf0eb36bc99b033f03b2c8e95d319f0044defae9b41ae21408e7e0cda48f"},
+]
+
+[package.dependencies]
+googleapis-common-protos = ">=1.5.5"
+grpcio = ">=1.62.2"
+protobuf = ">=4.21.6"
 
 [[package]]
 name = "h11"
@@ -1011,6 +1211,51 @@ gssapi = ["gssapi (>=1.6.9,<=1.8.2)"]
 opentelemetry = ["Deprecated (>=1.2.6)", "typing-extensions (>=3.7.4)", "zipp (>=0.5)"]
 
 [[package]]
+name = "numpy"
+version = "1.26.4"
+description = "Fundamental package for array computing in Python"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "numpy-1.26.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0"},
+    {file = "numpy-1.26.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a"},
+    {file = "numpy-1.26.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4"},
+    {file = "numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f"},
+    {file = "numpy-1.26.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a"},
+    {file = "numpy-1.26.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2"},
+    {file = "numpy-1.26.4-cp310-cp310-win32.whl", hash = "sha256:bfe25acf8b437eb2a8b2d49d443800a5f18508cd811fea3181723922a8a82b07"},
+    {file = "numpy-1.26.4-cp310-cp310-win_amd64.whl", hash = "sha256:b97fe8060236edf3662adfc2c633f56a08ae30560c56310562cb4f95500022d5"},
+    {file = "numpy-1.26.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71"},
+    {file = "numpy-1.26.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef"},
+    {file = "numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e"},
+    {file = "numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5"},
+    {file = "numpy-1.26.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a"},
+    {file = "numpy-1.26.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a"},
+    {file = "numpy-1.26.4-cp311-cp311-win32.whl", hash = "sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20"},
+    {file = "numpy-1.26.4-cp311-cp311-win_amd64.whl", hash = "sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2"},
+    {file = "numpy-1.26.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218"},
+    {file = "numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b"},
+    {file = "numpy-1.26.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b"},
+    {file = "numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed"},
+    {file = "numpy-1.26.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a"},
+    {file = "numpy-1.26.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0"},
+    {file = "numpy-1.26.4-cp312-cp312-win32.whl", hash = "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110"},
+    {file = "numpy-1.26.4-cp312-cp312-win_amd64.whl", hash = "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818"},
+    {file = "numpy-1.26.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7349ab0fa0c429c82442a27a9673fc802ffdb7c7775fad780226cb234965e53c"},
+    {file = "numpy-1.26.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:52b8b60467cd7dd1e9ed082188b4e6bb35aa5cdd01777621a1658910745b90be"},
+    {file = "numpy-1.26.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5241e0a80d808d70546c697135da2c613f30e28251ff8307eb72ba696945764"},
+    {file = "numpy-1.26.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f870204a840a60da0b12273ef34f7051e98c3b5961b61b0c2c1be6dfd64fbcd3"},
+    {file = "numpy-1.26.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:679b0076f67ecc0138fd2ede3a8fd196dddc2ad3254069bcb9faf9a79b1cebcd"},
+    {file = "numpy-1.26.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:47711010ad8555514b434df65f7d7b076bb8261df1ca9bb78f53d3b2db02e95c"},
+    {file = "numpy-1.26.4-cp39-cp39-win32.whl", hash = "sha256:a354325ee03388678242a4d7ebcd08b5c727033fcff3b2f536aea978e15ee9e6"},
+    {file = "numpy-1.26.4-cp39-cp39-win_amd64.whl", hash = "sha256:3373d5d70a5fe74a2c1bb6d2cfd9609ecf686d47a2d7b1d37a8f3b6bf6003aea"},
+    {file = "numpy-1.26.4-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:afedb719a9dcfc7eaf2287b839d8198e06dcd4cb5d276a3df279231138e83d30"},
+    {file = "numpy-1.26.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95a7476c59002f2f6c590b9b7b998306fba6a5aa646b1e22ddfeaf8f78c3a29c"},
+    {file = "numpy-1.26.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7e50d0a0cc3189f9cb0aeb3a6a6af18c16f59f004b866cd2be1c14b36134a4a0"},
+    {file = "numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010"},
+]
+
+[[package]]
 name = "packaging"
 version = "24.0"
 description = "Core utilities for Python packages"
@@ -1291,6 +1536,20 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+files = [
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "python-dotenv"
 version = "1.0.1"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -1437,6 +1696,74 @@ files = [
     {file = "ruff-0.4.3-py3-none-win_amd64.whl", hash = "sha256:7a1c3a450bc6539ef00da6c819fb1b76b6b065dec585f91456e7c0d6a0bbc725"},
     {file = "ruff-0.4.3-py3-none-win_arm64.whl", hash = "sha256:71ca5f8ccf1121b95a59649482470c5601c60a416bf189d553955b0338e34614"},
     {file = "ruff-0.4.3.tar.gz", hash = "sha256:ff0a3ef2e3c4b6d133fbedcf9586abfbe38d076041f2dc18ffb2c7e0485d5a07"},
+]
+
+[[package]]
+name = "shapely"
+version = "2.0.4"
+description = "Manipulation and analysis of geometric objects"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "shapely-2.0.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:011b77153906030b795791f2fdfa2d68f1a8d7e40bce78b029782ade3afe4f2f"},
+    {file = "shapely-2.0.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9831816a5d34d5170aa9ed32a64982c3d6f4332e7ecfe62dc97767e163cb0b17"},
+    {file = "shapely-2.0.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5c4849916f71dc44e19ed370421518c0d86cf73b26e8656192fcfcda08218fbd"},
+    {file = "shapely-2.0.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:841f93a0e31e4c64d62ea570d81c35de0f6cea224568b2430d832967536308e6"},
+    {file = "shapely-2.0.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b4431f522b277c79c34b65da128029a9955e4481462cbf7ebec23aab61fc58"},
+    {file = "shapely-2.0.4-cp310-cp310-win32.whl", hash = "sha256:92a41d936f7d6743f343be265ace93b7c57f5b231e21b9605716f5a47c2879e7"},
+    {file = "shapely-2.0.4-cp310-cp310-win_amd64.whl", hash = "sha256:30982f79f21bb0ff7d7d4a4e531e3fcaa39b778584c2ce81a147f95be1cd58c9"},
+    {file = "shapely-2.0.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:de0205cb21ad5ddaef607cda9a3191eadd1e7a62a756ea3a356369675230ac35"},
+    {file = "shapely-2.0.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7d56ce3e2a6a556b59a288771cf9d091470116867e578bebced8bfc4147fbfd7"},
+    {file = "shapely-2.0.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:58b0ecc505bbe49a99551eea3f2e8a9b3b24b3edd2a4de1ac0dc17bc75c9ec07"},
+    {file = "shapely-2.0.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:790a168a808bd00ee42786b8ba883307c0e3684ebb292e0e20009588c426da47"},
+    {file = "shapely-2.0.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4310b5494271e18580d61022c0857eb85d30510d88606fa3b8314790df7f367d"},
+    {file = "shapely-2.0.4-cp311-cp311-win32.whl", hash = "sha256:63f3a80daf4f867bd80f5c97fbe03314348ac1b3b70fb1c0ad255a69e3749879"},
+    {file = "shapely-2.0.4-cp311-cp311-win_amd64.whl", hash = "sha256:c52ed79f683f721b69a10fb9e3d940a468203f5054927215586c5d49a072de8d"},
+    {file = "shapely-2.0.4-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:5bbd974193e2cc274312da16b189b38f5f128410f3377721cadb76b1e8ca5328"},
+    {file = "shapely-2.0.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:41388321a73ba1a84edd90d86ecc8bfed55e6a1e51882eafb019f45895ec0f65"},
+    {file = "shapely-2.0.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0776c92d584f72f1e584d2e43cfc5542c2f3dd19d53f70df0900fda643f4bae6"},
+    {file = "shapely-2.0.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c75c98380b1ede1cae9a252c6dc247e6279403fae38c77060a5e6186c95073ac"},
+    {file = "shapely-2.0.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c3e700abf4a37b7b8b90532fa6ed5c38a9bfc777098bc9fbae5ec8e618ac8f30"},
+    {file = "shapely-2.0.4-cp312-cp312-win32.whl", hash = "sha256:4f2ab0faf8188b9f99e6a273b24b97662194160cc8ca17cf9d1fb6f18d7fb93f"},
+    {file = "shapely-2.0.4-cp312-cp312-win_amd64.whl", hash = "sha256:03152442d311a5e85ac73b39680dd64a9892fa42bb08fd83b3bab4fe6999bfa0"},
+    {file = "shapely-2.0.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:994c244e004bc3cfbea96257b883c90a86e8cbd76e069718eb4c6b222a56f78b"},
+    {file = "shapely-2.0.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:05ffd6491e9e8958b742b0e2e7c346635033d0a5f1a0ea083547fcc854e5d5cf"},
+    {file = "shapely-2.0.4-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fbdc1140a7d08faa748256438291394967aa54b40009f54e8d9825e75ef6113"},
+    {file = "shapely-2.0.4-cp37-cp37m-win32.whl", hash = "sha256:5af4cd0d8cf2912bd95f33586600cac9c4b7c5053a036422b97cfe4728d2eb53"},
+    {file = "shapely-2.0.4-cp37-cp37m-win_amd64.whl", hash = "sha256:464157509ce4efa5ff285c646a38b49f8c5ef8d4b340f722685b09bb033c5ccf"},
+    {file = "shapely-2.0.4-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:489c19152ec1f0e5c5e525356bcbf7e532f311bff630c9b6bc2db6f04da6a8b9"},
+    {file = "shapely-2.0.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b79bbd648664aa6f44ef018474ff958b6b296fed5c2d42db60078de3cffbc8aa"},
+    {file = "shapely-2.0.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:674d7baf0015a6037d5758496d550fc1946f34bfc89c1bf247cabdc415d7747e"},
+    {file = "shapely-2.0.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6cd4ccecc5ea5abd06deeaab52fcdba372f649728050c6143cc405ee0c166679"},
+    {file = "shapely-2.0.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb5cdcbbe3080181498931b52a91a21a781a35dcb859da741c0345c6402bf00c"},
+    {file = "shapely-2.0.4-cp38-cp38-win32.whl", hash = "sha256:55a38dcd1cee2f298d8c2ebc60fc7d39f3b4535684a1e9e2f39a80ae88b0cea7"},
+    {file = "shapely-2.0.4-cp38-cp38-win_amd64.whl", hash = "sha256:ec555c9d0db12d7fd777ba3f8b75044c73e576c720a851667432fabb7057da6c"},
+    {file = "shapely-2.0.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:3f9103abd1678cb1b5f7e8e1af565a652e036844166c91ec031eeb25c5ca8af0"},
+    {file = "shapely-2.0.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:263bcf0c24d7a57c80991e64ab57cba7a3906e31d2e21b455f493d4aab534aaa"},
+    {file = "shapely-2.0.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ddf4a9bfaac643e62702ed662afc36f6abed2a88a21270e891038f9a19bc08fc"},
+    {file = "shapely-2.0.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:485246fcdb93336105c29a5cfbff8a226949db37b7473c89caa26c9bae52a242"},
+    {file = "shapely-2.0.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8de4578e838a9409b5b134a18ee820730e507b2d21700c14b71a2b0757396acc"},
+    {file = "shapely-2.0.4-cp39-cp39-win32.whl", hash = "sha256:9dab4c98acfb5fb85f5a20548b5c0abe9b163ad3525ee28822ffecb5c40e724c"},
+    {file = "shapely-2.0.4-cp39-cp39-win_amd64.whl", hash = "sha256:31c19a668b5a1eadab82ff070b5a260478ac6ddad3a5b62295095174a8d26398"},
+    {file = "shapely-2.0.4.tar.gz", hash = "sha256:5dc736127fac70009b8d309a0eeb74f3e08979e530cf7017f2f507ef62e6cfb8"},
+]
+
+[package.dependencies]
+numpy = ">=1.14,<3"
+
+[package.extras]
+docs = ["matplotlib", "numpydoc (==1.1.*)", "sphinx", "sphinx-book-theme", "sphinx-remove-toctrees"]
+test = ["pytest", "pytest-cov"]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 
 [[package]]
@@ -1850,4 +2177,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "177010ade24dba1e46f08ad339aca60721cebac2a37de2bc6a97653c294a181f"
+content-hash = "0b0da8f8658f5f573913ea613f903dd65f715462c2ff5c7dceff29ca1b4f17e6"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,6 +20,7 @@ google-cloud-storage = "^2.16.0"
 alembic = "^1.13.1"
 sqlalchemy-utils = "^0.41.2"
 python-dotenv = "^1.0.1"
+google-cloud-aiplatform = "^1.53.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -5,3 +5,5 @@ addopts =
     -ra
 testpaths = tests
 asyncio_mode = auto
+filterwarnings =
+    ignore::DeprecationWarning:vertexai.preview

--- a/backend/tests/test_gemini_request.py
+++ b/backend/tests/test_gemini_request.py
@@ -1,0 +1,45 @@
+import pytest
+from unittest.mock import patch, Mock
+from app.utils.gemini_request import generate_content
+from pytest import MonkeyPatch
+
+
+# 環境変数を設定するフィクスチャ
+@pytest.fixture
+def mock_env_vars(monkeypatch: MonkeyPatch) -> None:
+    # 環境変数を設定
+    monkeypatch.setenv("PROJECT_ID", "your_project_id")
+    monkeypatch.setenv("REGION", "your_region")
+
+
+# GenerativeModelクラスをモック
+@patch("app.utils.gemini_request.GenerativeModel", autospec=True)
+def test_generate_content(mock_GenerativeModel: Mock, mock_env_vars: None) -> None:
+    # フィクスチャを適用
+    mock_env_vars
+
+    # モックの設定
+    mock_model = mock_GenerativeModel.return_value
+    mock_response = mock_model.generate_content.return_value
+    mock_response.text = "mocked response text"
+
+    # テストデータ
+    pdf_file_uri = "gs://ai-notebook-test001/5_アジャイルⅡ.pdf"
+    prompt = """
+    あなたは、わかりやすく丁寧に教えることで評判の大学教授です。
+    ソフトウェア工学についてのスライド資料と解説です。
+    この資料と解説に基づいて、わかりやすく、親しみやすい解説がついていて、誰もが読みたくなるような整理ノートを作成して下さい。
+    ビジュアル的にもわかりやすくするため、マークダウンで文字の大きさ、強調表示などのスタイルを作成して、スライド資料の図を複数挿入できるようにスライドのページと配置を指定してください。
+    また、コラムや用語解説を複数つけて、興味を持てるようにしてください。
+    最後に選択式と穴埋め式の練習問題を付けてください。
+    問題の解答は、最後に別枠で記載してください。
+    出力のファイル形式は、マークダウンのファイルで出力してください。
+    """
+
+    # テスト対象関数の実行
+    result = generate_content(pdf_file_uri, prompt)
+
+    # アサーション（検証）
+    mock_GenerativeModel.assert_called_once_with(model_name="gemini-1.5-pro-001")
+    mock_model.generate_content.assert_called_once()
+    assert result == "mocked response text"

--- a/backend/tests/test_gemini_request.py
+++ b/backend/tests/test_gemini_request.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import patch, Mock
 from app.utils.gemini_request import generate_content
 from pytest import MonkeyPatch
+from google.api_core.exceptions import GoogleAPIError, InvalidArgument, NotFound
 
 
 # 環境変数を設定するフィクスチャ
@@ -17,28 +18,176 @@ MODEL_NAME = "gemini-1.5-pro-001"
 GENERATION_CONFIG = {
     "temperature": 0.1,
     "max_output_tokens": 8192,
-    "response_mime_type": "application/json",
 }
 
 
 # GenerativeModelクラスをモック
 @patch("app.utils.gemini_request.GenerativeModel", autospec=True)
-def test_generate_content(mock_GenerativeModel: Mock, mock_env_vars: None) -> None:
+@pytest.mark.asyncio
+async def test_generate_content(
+    mock_GenerativeModel: Mock, mock_env_vars: None
+) -> None:
     # フィクスチャを適用
     mock_env_vars
 
     # モックの設定
     mock_model = mock_GenerativeModel.return_value
     mock_response = mock_model.generate_content.return_value
-    mock_response.text = {"response": "mocked response text"}
+    mock_response.text = "モックのレスポンステキスト"
 
     # テストデータ
     files = ["1_ソフトウェア工学の誕生.pdf", "5_アジャイルⅡ.pdf"]
 
     # テスト対象関数の実行
-    result = generate_content(files)
+    result = await generate_content(files)
 
     # アサーション（検証）
     mock_GenerativeModel.assert_called_once_with(model_name=MODEL_NAME)
     mock_model.generate_content.assert_called_once()
-    assert result == {"response": "mocked response text"}
+    assert result == "モックのレスポンステキスト"
+
+
+# エラーハンドリングのテスト（ファイルが見つからない場合）
+@patch("app.utils.gemini_request.GenerativeModel", autospec=True)
+@pytest.mark.asyncio
+async def test_generate_content_file_not_found(
+    mock_GenerativeModel: Mock, mock_env_vars: None
+) -> None:
+    # フィクスチャを適用
+    mock_env_vars
+
+    # テストデータ
+    files = ["non_existent_file.pdf"]
+
+    # モックの設定
+    mock_model = mock_GenerativeModel.return_value
+    mock_model.generate_content.side_effect = NotFound("File not found")
+
+    # テスト対象関数の実行とエラーハンドリングの確認
+    with pytest.raises(NotFound) as excinfo:
+        await generate_content(files)
+
+    # アサーション（検証）
+    assert str(excinfo.value) == "404 File not found"
+
+
+# エラーハンドリングのテスト（無効な引数）
+@patch("app.utils.gemini_request.GenerativeModel", autospec=True)
+@pytest.mark.asyncio
+async def test_generate_content_invalid_argument(
+    mock_GenerativeModel: Mock, mock_env_vars: None
+) -> None:
+    # フィクスチャを適用
+    mock_env_vars
+
+    # テストデータ
+    files = ["invalid_format.txt"]
+
+    # モックの設定
+    mock_model = mock_GenerativeModel.return_value
+    mock_model.generate_content.side_effect = InvalidArgument("Invalid file format")
+
+    # テスト対象関数の実行とエラーハンドリングの確認
+    with pytest.raises(InvalidArgument) as excinfo:
+        await generate_content(files)
+
+    # アサーション（検証）
+    assert str(excinfo.value) == "400 Invalid file format"
+
+
+# エラーハンドリングのテスト（Google APIエラー）
+@patch("app.utils.gemini_request.GenerativeModel", autospec=True)
+@pytest.mark.asyncio
+async def test_generate_content_google_api_error(
+    mock_GenerativeModel: Mock, mock_env_vars: None
+) -> None:
+    # フィクスチャを適用
+    mock_env_vars
+
+    # テストデータ
+    files = ["1_ソフトウェア工学の誕生.pdf", "5_アジャイルⅡ.pdf"]
+
+    # モックの設定
+    mock_model = mock_GenerativeModel.return_value
+    mock_model.generate_content.side_effect = GoogleAPIError("Google API error")
+
+    # テスト対象関数の実行とエラーハンドリングの確認
+    with pytest.raises(GoogleAPIError) as excinfo:
+        await generate_content(files)
+
+    # アサーション（検証）
+    assert str(excinfo.value) == "Google API error"
+
+
+# エラーハンドリングのテスト（その他の予期しないエラー）
+@patch("app.utils.gemini_request.GenerativeModel", autospec=True)
+@pytest.mark.asyncio
+async def test_generate_content_unexpected_error(
+    mock_GenerativeModel: Mock, mock_env_vars: None
+) -> None:
+    # フィクスチャを適用
+    mock_env_vars
+
+    # テストデータ
+    files = ["1_ソフトウェア工学の誕生.pdf", "5_アジャイルⅡ.pdf"]
+
+    # モックの設定
+    mock_model = mock_GenerativeModel.return_value
+    mock_model.generate_content.side_effect = Exception("Unexpected error")
+
+    # テスト対象関数の実行とエラーハンドリングの確認
+    with pytest.raises(Exception) as excinfo:
+        await generate_content(files)
+
+    # アサーション（検証）
+    assert str(excinfo.value) == "Unexpected error"
+
+
+# エラーハンドリングのテスト（モデル属性エラー）
+@patch("app.utils.gemini_request.GenerativeModel", autospec=True)
+@pytest.mark.asyncio
+async def test_generate_content_attribute_error(
+    mock_GenerativeModel: Mock, mock_env_vars: None
+) -> None:
+    # フィクスチャを適用
+    mock_env_vars
+
+    # テストデータ
+    files = ["1_ソフトウェア工学の誕生.pdf", "5_アジャイルⅡ.pdf"]
+
+    # モックの設定
+    mock_model = mock_GenerativeModel.return_value
+    mock_model.generate_content.side_effect = AttributeError("Model attribute error")
+
+    # テスト対象関数の実行とエラーハンドリングの確認
+    with pytest.raises(AttributeError) as excinfo:
+        await generate_content(files)
+
+    # アサーション（検証）
+    assert str(excinfo.value) == "Model attribute error"
+
+
+# エラーハンドリングのテスト（タイプエラー）
+@patch("app.utils.gemini_request.GenerativeModel", autospec=True)
+@pytest.mark.asyncio
+async def test_generate_content_type_error(
+    mock_GenerativeModel: Mock, mock_env_vars: None
+) -> None:
+    # フィクスチャを適用
+    mock_env_vars
+
+    # テストデータ
+    files = ["1_ソフトウェア工学の誕生.pdf", "5_アジャイルⅡ.pdf"]
+
+    # モックの設定
+    mock_model = mock_GenerativeModel.return_value
+    mock_model.generate_content.side_effect = TypeError(
+        "Type error in model generation"
+    )
+
+    # テスト対象関数の実行とエラーハンドリングの確認
+    with pytest.raises(TypeError) as excinfo:
+        await generate_content(files)
+
+    # アサーション（検証）
+    assert str(excinfo.value) == "Type error in model generation"

--- a/backend/tests/test_gemini_request.py
+++ b/backend/tests/test_gemini_request.py
@@ -12,6 +12,15 @@ def mock_env_vars(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("REGION", "your_region")
 
 
+# テストデータ
+MODEL_NAME = "gemini-1.5-pro-001"
+GENERATION_CONFIG = {
+    "temperature": 0.1,
+    "max_output_tokens": 8192,
+    "response_mime_type": "application/json",
+}
+
+
 # GenerativeModelクラスをモック
 @patch("app.utils.gemini_request.GenerativeModel", autospec=True)
 def test_generate_content(mock_GenerativeModel: Mock, mock_env_vars: None) -> None:
@@ -21,25 +30,15 @@ def test_generate_content(mock_GenerativeModel: Mock, mock_env_vars: None) -> No
     # モックの設定
     mock_model = mock_GenerativeModel.return_value
     mock_response = mock_model.generate_content.return_value
-    mock_response.text = "mocked response text"
+    mock_response.text = {"response": "mocked response text"}
 
     # テストデータ
-    pdf_file_uri = "gs://ai-notebook-test001/5_アジャイルⅡ.pdf"
-    prompt = """
-    あなたは、わかりやすく丁寧に教えることで評判の大学教授です。
-    ソフトウェア工学についてのスライド資料と解説です。
-    この資料と解説に基づいて、わかりやすく、親しみやすい解説がついていて、誰もが読みたくなるような整理ノートを作成して下さい。
-    ビジュアル的にもわかりやすくするため、マークダウンで文字の大きさ、強調表示などのスタイルを作成して、スライド資料の図を複数挿入できるようにスライドのページと配置を指定してください。
-    また、コラムや用語解説を複数つけて、興味を持てるようにしてください。
-    最後に選択式と穴埋め式の練習問題を付けてください。
-    問題の解答は、最後に別枠で記載してください。
-    出力のファイル形式は、マークダウンのファイルで出力してください。
-    """
+    files = ["1_ソフトウェア工学の誕生.pdf", "5_アジャイルⅡ.pdf"]
 
     # テスト対象関数の実行
-    result = generate_content(pdf_file_uri, prompt)
+    result = generate_content(files)
 
     # アサーション（検証）
-    mock_GenerativeModel.assert_called_once_with(model_name="gemini-1.5-pro-001")
+    mock_GenerativeModel.assert_called_once_with(model_name=MODEL_NAME)
     mock_model.generate_content.assert_called_once()
-    assert result == "mocked response text"
+    assert result == {"response": "mocked response text"}

--- a/backend/tests/test_routers_outputs.py
+++ b/backend/tests/test_routers_outputs.py
@@ -1,0 +1,117 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from unittest.mock import patch, AsyncMock, Mock
+from fastapi import FastAPI
+from pytest import MonkeyPatch
+from app.routers.outputs import router
+from google.api_core.exceptions import GoogleAPIError, InvalidArgument, NotFound
+
+# FastAPIアプリケーションにルーターを追加
+app = FastAPI()
+app.include_router(router)
+
+
+# 環境変数を設定するフィクスチャ
+@pytest.fixture
+def mock_env_vars(monkeypatch: MonkeyPatch) -> None:
+    # 環境変数を設定
+    monkeypatch.setenv("PROJECT_ID", "your_project_id")
+    monkeypatch.setenv("REGION", "your_region")
+
+
+@pytest.mark.asyncio
+@patch("app.routers.outputs.generate_content", new_callable=AsyncMock)
+async def test_request_content_success(
+    mock_generate_content: Mock, mock_env_vars: None
+) -> None:
+    # フィクスチャを適用
+    mock_env_vars
+
+    mock_generate_content.return_value = "生成されたコンテンツ"
+
+    transport = ASGITransport(app=app)  # type: ignore
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.post("/outputs/request", json=["file1.pdf", "file2.pdf"])
+
+    assert response.status_code == 200
+    assert response.json() == "生成されたコンテンツ"
+    mock_generate_content.assert_called_once_with(["file1.pdf", "file2.pdf"])
+
+
+@pytest.mark.asyncio
+@patch("app.routers.outputs.generate_content", new_callable=AsyncMock)
+async def test_request_content_file_not_found(
+    mock_generate_content: Mock, mock_env_vars: None
+) -> None:
+    # フィクスチャを適用
+    mock_env_vars
+    mock_generate_content.side_effect = NotFound("File not found")
+
+    transport = ASGITransport(app=app)  # type: ignore
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.post("/outputs/request", json=["non_existent_file.pdf"])
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "detail": "指定されたファイルがGoogle Cloud Storageに見つかりません。"
+        + "ファイル名を再確認してください。"
+    }
+
+
+@pytest.mark.asyncio
+@patch("app.routers.outputs.generate_content", new_callable=AsyncMock)
+async def test_request_content_invalid_argument(
+    mock_generate_content: Mock, mock_env_vars: None
+) -> None:
+    # フィクスチャを適用
+    mock_env_vars
+    mock_generate_content.side_effect = InvalidArgument("Invalid file format")
+
+    transport = ASGITransport(app=app)  # type: ignore
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.post("/outputs/request", json=["invalid_format.txt"])
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": "ファイル名の形式が無効です。有効なファイル名を指定してください。"
+    }
+
+
+@pytest.mark.asyncio
+@patch("app.routers.outputs.generate_content", new_callable=AsyncMock)
+async def test_request_content_google_api_error(
+    mock_generate_content: Mock, mock_env_vars: None
+) -> None:
+    # フィクスチャを適用
+    mock_env_vars
+    mock_generate_content.side_effect = GoogleAPIError("Google API error")
+
+    transport = ASGITransport(app=app)  # type: ignore
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.post("/outputs/request", json=["file1.pdf", "file2.pdf"])
+
+    assert response.status_code == 500
+    assert response.json() == {
+        "detail": "Google APIからエラーが返されました。"
+        + "システム管理者に連絡してください。"
+    }
+
+
+@pytest.mark.asyncio
+@patch("app.routers.outputs.generate_content", new_callable=AsyncMock)
+async def test_request_content_unexpected_error(
+    mock_generate_content: Mock, mock_env_vars: None
+) -> None:
+    # フィクスチャを適用
+    mock_env_vars
+    mock_generate_content.side_effect = Exception("Unexpected error")
+
+    transport = ASGITransport(app=app)  # type: ignore
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.post("/outputs/request", json=["file1.pdf", "file2.pdf"])
+
+    assert response.status_code == 500
+    assert response.json() == {
+        "detail": "コンテンツの生成中に予期せぬエラーが発生しました。"
+        + "システム管理者に連絡してください。"
+    }


### PR DESCRIPTION
## Issue No.
#42 

## 影響範囲とその理由
Dockerfile.backendにGoogle Cloud SDKを追加したため、イメージのリビルドが必要

## チェックリスト
<!-- 変更を行った際にチェックした項目にチェックを入れてください。 -->
- [x] 単体テストを実施した
- [ ] 統合テストを実施した
- [ ] ドキュメントを更新した

## スクリーンショット
<!-- UIの変更がある場合は、Before / Afterのスクリーンショットや動作が分かるGIFなどを添付してください。 -->

## レビュアーに確認してほしいこと 
まだ、geminiへの問い合わせ部分しか実装しておらず、フロントからのAPIにはつなげていないです。
README.mdに記載しましたが、コンテナ内でもgcloudコマンドでサービスアカウントキーが有効になるか確認して欲しいです。

## 関連リンク
<!-- ソースコードに関連するファイルがあればリンクを共有 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - Vertex AIを使用して複数のPDFファイルとプロンプトを組み合わせてコンテンツを生成する機能を追加しました。

- **ドキュメント**
  - Google VertexAIをローカル環境で使用するための手順をREADMEに追加しました。

- **バグ修正**
  - Alembicマイグレーションスクリプトのタイプアノテーションを修正しました。

- **リファクタリング**
  - FastAPIアプリケーションに新しい`outputs`ルーターを追加しました。
  - `users`エンドポイントのレスポンスモデルの型宣言を修正しました。

- **テスト**
  - `generate_content`関数のテストケースを追加しました。

- **スタイル**
  - いくつかの変数宣言のタイプアノテーションを削除しました。

- **雑務**
  - `poetry`と`gcloud SDK`のインストール手順をDockerfileに追加しました。
  - `google-cloud-aiplatform`依存関係を追加しました。
  - `DeprecationWarning`を無視するための設定をpytest.iniに追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->