### PR TITLE
GitHub Actionsバグ修正＆READMEの重複行修正&

### DIFF
--- a/backend/app/routers/outputs.py
+++ b/backend/app/routers/outputs.py
@@ -4,13 +4,12 @@ from datetime import datetime, timedelta, timezone
 
 from dotenv import load_dotenv
 from fastapi import APIRouter, Depends, HTTPException
+from google.api_core.exceptions import GoogleAPIError, InvalidArgument, NotFound
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import app.cruds.outputs as outputs_cruds
 import app.schemas.outputs as outputs_schemas
 from app.database import get_db
-
-from google.api_core.exceptions import GoogleAPIError, InvalidArgument, NotFound
 from app.utils.gemini_request import generate_content
 
 # 環境変数を読み込む
@@ -87,6 +86,7 @@ async def delete_output(output_id: int, db: AsyncSession = db_dependency) -> dic
     await outputs_cruds.delete_output(db, output)
     return {"detail": "学習帳が削除されました"}
 
+
 # 複数のファイル名のリストを入力して、出力を生成するエンドポイント
 @router.post("/request", response_model=str)
 async def request_content(files: list[str]) -> str:
@@ -128,4 +128,3 @@ async def request_content(files: list[str]) -> str:
         ) from e
 
     return content
-

--- a/backend/tests/test_routers_outputs.py
+++ b/backend/tests/test_routers_outputs.py
@@ -10,15 +10,18 @@ from fastapi import FastAPI
 from pytest import MonkeyPatch
 from app.main import app
 from app.models.users import User
-from app.routers.outputs import router
+
+# from app.routers.outputs import router
 from google.api_core.exceptions import GoogleAPIError, InvalidArgument, NotFound
 
 # .envから環境変数を読み込む
 load_dotenv()
 
-# FastAPIアプリケーションにルーターを追加
-app = FastAPI()
-app.include_router(router)
+# app.routers.outputsに関連するモックを使ってないのでコメントアウトしてエラー解消
+# # FastAPIアプリケーションにルーターを追加
+# app = FastAPI()
+# app.include_router(router)
+
 
 # 環境変数を設定するフィクスチャ
 @pytest.fixture
@@ -26,7 +29,8 @@ def mock_env_vars(monkeypatch: MonkeyPatch) -> None:
     # 環境変数を設定
     monkeypatch.setenv("PROJECT_ID", "your_project_id")
     monkeypatch.setenv("REGION", "your_region")
-    
+
+
 # sessionフィクスチャを提供するフィクスチャを定義
 @pytest.fixture
 async def session(
@@ -55,7 +59,7 @@ async def test_upload_outputs(session: AsyncSession) -> None:
         "output": "テストマークダウン🚀",
         "user_id": user_id,
         "created_at": "2024-06-08T06:38:33.149Z",
-        "id": 0
+        "id": 0,
     }
 
     async with AsyncClient(
@@ -84,7 +88,7 @@ async def test_get_outputs(session: AsyncSession) -> None:
             "output": "テストマークダウン🚀",
             "user_id": user_id,
             "created_at": "2024-06-08T06:38:33.149Z",
-            "id": 0
+            "id": 0,
         }
         await client.post(f"/outputs/upload?user_id={user_id}", json=outputs)
 
@@ -109,7 +113,7 @@ async def test_get_output_by_id(session: AsyncSession) -> None:
             "output": "テストマークダウン🚀",
             "user_id": user_id,
             "created_at": "2024-06-08T06:38:33.149Z",
-            "id": 0
+            "id": 0,
         }
         upload_response = await client.post(
             f"/outputs/upload?user_id={user_id}", json=outputs
@@ -140,7 +144,7 @@ async def test_delete_output(session: AsyncSession) -> None:
             "output": "テストマークダウン🚀",
             "user_id": user_id,
             "created_at": "2024-06-08T06:38:33.149Z",
-            "id": 0
+            "id": 0,
         }
 
         upload_response = await client.post(
@@ -184,7 +188,8 @@ async def test_delete_output_not_found(session: AsyncSession) -> None:
         assert response.status_code == 404
         data = response.json()
         assert data["detail"] == "学習帳が見つかりません"
-        
+
+
 # 正常にコンテンツが生成される場合のテスト
 @pytest.mark.asyncio
 @patch("app.routers.outputs.generate_content", new_callable=AsyncMock)


### PR DESCRIPTION
## Issue No.
対応しているイシューはありません。
（間違えてmainブランチにpushしたら、なぜか一部反映されてしまいました）

## 影響範囲とその理由
- GitHub Actionsのpytestエラーが見逃されるバグを修正（set -euo pipefail追加）
- READMEの重複行を削除（以前コードラビットの指摘を反映したら重複してしまったため）
- test_routers_outputs.pyのエラー解消（mainにマージされているコードでエラーが起きているため）
- frontendでpytestが異常終了しているのは、testコードがないためです。

## チェックリスト
<!-- 変更を行った際にチェックした項目にチェックを入れてください。 -->
- [x] 単体テストを実施した
- [ ] 統合テストを実施した
- [ ] ドキュメントを更新した

## スクリーンショット
<!-- UIの変更がある場合は、Before / Afterのスクリーンショットや動作が分かるGIFなどを添付してください。 -->

## レビュアーに確認してほしいこと 
<!-- テストや事象の再現が必要な場合、レビュアーが再現できる実施手順を必ず明記してください！ -->
<!-- レビュワーに特に注目してほしいポイントや、不安な部分があれば明記してください。 -->

## 関連リンク
<!-- ソースコードに関連するファイルがあればリンクを共有 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - `delete_output` 関数内のコメントにスペースを追加しました。
  - `request_content` 関数の戻り値の型を `str` に変更しました。

- **テスト**
  - 使用されていないモックに関連して、テストファイルで `app.routers.outputs` からのルーターのインクルードをコメントアウトしました。
  - 辞書エントリのフォーマットを修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->