### PR TITLE
コンソールからMySQLに接続した際もデフォルトでutf8mb4に対応するように修正

### DIFF
--- a/backend/my.cnf
+++ b/backend/my.cnf
@@ -1,0 +1,5 @@
+[mysql]
+default-character-set = utf8mb4
+
+[client]
+default-character-set = utf8mb4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       TZ: 'Asia/Tokyo'
     volumes:
       - dev-mysql-data:/var/lib/mysql    
+      - ./backend/my.cnf:/etc/mysql/conf.d/my.cnf
     ports:
       - 3306:3306
     networks:
@@ -55,7 +56,8 @@ services:
       MYSQL_DATABASE: 'test-db'
       TZ: 'Asia/Tokyo'
     volumes:
-      - test-mysql-data:/var/lib/mysql    
+      - test-mysql-data:/var/lib/mysql
+      - ./backend/my.cnf:/etc/mysql/conf.d/my.cnf
     ports:
       - 3307:3306
     networks:


### PR DESCRIPTION
## Issue No.
なし

## 影響範囲とその理由
コンソールからMySQLに接続した際もデフォルトでutf8mb4に対応するように修正

## チェックリスト
- [X] 単体テストを実施した
- [ ] 統合テストを実施した
- [ ] ドキュメントを更新した

## スクリーンショット

## レビュアーに確認してほしいこと 
### dev-db
以下のコマンドでコンソールからmysqlにログイン
`docker compose exec dev-db mysql dev-db`

charsetの設定を確認して、以下のようになっていることを確認
`show variables like '%char%';`
<img width="289" alt="image" src="https://github.com/AIIT-Oikawa-PBL-2024/AI-Notebook/assets/130154894/49be8890-aa9c-4479-9caa-6174da535014">

以下のselect文の実行結果が正常に取得できることを確認
`select * from outputs\G`
<img width="584" alt="image" src="https://github.com/AIIT-Oikawa-PBL-2024/AI-Notebook/assets/130154894/a9dc08c8-e149-4be3-b98b-12541301436c">

### test-db
以下のコマンドでコンソールからmysqlにログイン
`docker compose exec test-db mysql test-db`

charsetの設定を確認して、以下のようになっていることを確認
※test-dbはこれだけでOK、test-dbはテスト実行後にテーブルをdropしていてデータを確認出来ないため
`show variables like '%char%';`
<img width="437" alt="image" src="https://github.com/AIIT-Oikawa-PBL-2024/AI-Notebook/assets/130154894/7abcdbe7-01c9-4c48-8b99-162cc1526d0e">

## 関連リンク


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - MySQLのデフォルト文字セットを`utf8mb4`に設定しました。

- **ドキュメント**
  - `docker-compose.yml`に`my.cnf`のボリュームマッピングを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->