### PR TITLE
(frontend) ファイル選択のエラーハンドリングとoutput.pyのutilsディレクトリへの移動

### DIFF
--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -1,4 +1,5 @@
 import logging
+import unicodedata
 from datetime import datetime, timedelta, timezone
 
 from dotenv import load_dotenv
@@ -45,11 +46,14 @@ async def upload_files(
 
     for file in files:
         if file.filename and file.size:
+            # ファイル名を正規化
+            normalized_filename = unicodedata.normalize("NFC", file.filename)
+
             # 日本時間の現在日時を取得
             now_japan = datetime.now(JST)
 
             file_create = files_schemas.FileCreate(
-                file_name=file.filename,
+                file_name=normalized_filename,
                 file_size=file.size,
                 user_id=1,  # ユーザIDは仮で1を設定
                 created_at=now_japan,  # 日本時間の現在日時を設定

--- a/backend/app/utils/operate_cloud_storage.py
+++ b/backend/app/utils/operate_cloud_storage.py
@@ -1,5 +1,6 @@
 import io
 import os
+import unicodedata
 
 from dotenv import load_dotenv
 from fastapi import HTTPException, UploadFile
@@ -49,11 +50,15 @@ async def upload_files(ext_correct_files: list[UploadFile]) -> dict:
     bucket_name = os.getenv("BUCKET_NAME")
 
     for file in ext_correct_files:
+        # ブロブ名を正規化
+        if file.filename:
+            normalized_blobname = unicodedata.normalize("NFC", file.filename)
+
         client = storage.Client.from_service_account_json(credentials)
         bucket = storage.Bucket(client, bucket_name)
         file_content = await file.read()
         file_obj = io.BytesIO(file_content)
-        destination_blob_name = file.filename
+        destination_blob_name = normalized_blobname
         blob = bucket.blob(destination_blob_name)
         file_obj.seek(0)
         try:

--- a/backend/tests/test_operate_cloud_strage.py
+++ b/backend/tests/test_operate_cloud_strage.py
@@ -6,8 +6,9 @@ from fastapi import UploadFile, HTTPException
 from fastapi.testclient import TestClient
 from app.utils.operate_cloud_storage import post_files, upload_files
 from app.main import app
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from google.api_core.exceptions import GoogleAPIError
+import unicodedata
 
 
 load_dotenv()  # 環境変数の読み込み
@@ -107,3 +108,47 @@ async def test_upload_files_with_failure() -> None:
         assert (
             "Upload failed" in result["failed_files"]
         )  # 失敗したファイルのエラーメッセージを検証
+
+
+# NFD形式の日本語ファイル名のブロブ名がNFC形式に正規化されていることを確認するテスト
+@pytest.mark.asyncio
+async def test_upload_files_nfc_normalization() -> None:
+    # NFD形式（濁点が分離された形式）の日本語ファイル名
+    nfd_filename = (
+        "テスト" + "\u3099" + "ファイル.pdf"
+    )  # "テストゞファイル.pdf"のNFD形式
+    nfc_filename = unicodedata.normalize("NFC", nfd_filename)
+
+    # BytesIOでダミーファイルを作成
+    dummy_content = b"dummy pdf content"
+    file = UploadFile(file=io.BytesIO(dummy_content), filename=nfd_filename)
+
+    # Google Cloud Storageのモックを作成
+    mock_blob = MagicMock()
+    mock_bucket = MagicMock()
+    mock_bucket.blob.return_value = mock_blob
+    mock_client = MagicMock()
+    mock_client.bucket.return_value = mock_bucket
+
+    # パッチを適用してGoogle Cloud Storageの操作をモック
+    with (
+        patch(
+            "google.cloud.storage.Client.from_service_account_json",
+            return_value=mock_client,
+        ),
+        patch("google.cloud.storage.Bucket", return_value=mock_bucket),
+        patch("os.getenv", return_value="mock_value"),
+    ):
+        # upload_files関数を呼び出す
+        result = await upload_files([file])
+
+        # アサーション
+        assert result["success"] is True
+        assert len(result["success_files"]) == 1
+
+        # bucket.blob()が正規化されたファイル名で呼び出されたことを確認
+        mock_bucket.blob.assert_called_once()
+        called_filename = mock_bucket.blob.call_args[0][0]
+        assert called_filename == nfc_filename
+        assert called_filename != nfd_filename
+        assert unicodedata.is_normalized("NFC", called_filename)

--- a/frontend/app/pages/select_files.py
+++ b/frontend/app/pages/select_files.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import os
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 
 import httpx
 import pandas as pd
@@ -13,13 +13,12 @@ load_dotenv()
 
 # ログの設定
 logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 # バックエンドAPIのURL
 BACKEND_HOST = os.getenv("BACKEND_HOST")
 BACKEND_DEV_API_URL = f"{BACKEND_HOST}/files/"
 
-# 日本のタイムゾーンを設定
-JST = timezone(timedelta(hours=9))
 
 # セッション状態の初期化
 if "note_name" not in st.session_state:
@@ -32,22 +31,32 @@ if "selected_files" not in st.session_state:
     st.session_state.selected_files = []
 
 
-# UTCをJSTに変換する関数
-def utc_to_jst(utc_str: str) -> str:
-    utc_time = datetime.fromisoformat(utc_str.replace("Z", "+00:00"))
-    jst_time = utc_time.astimezone(JST)
+# 時刻フォーマットを変換する関数
+def time_format(jst_str: str) -> str:
+    jst_time = datetime.fromisoformat(jst_str.replace("Z", "+00:00"))
     return jst_time.strftime("%Y-%m-%d %H:%M:%S")
 
 
 # 非同期でファイル一覧を取得する関数
 async def get_files_list() -> list[str]:
-    async with httpx.AsyncClient() as client:
-        response = await client.get(
-            BACKEND_DEV_API_URL, timeout=100, headers={"accept": "application/json"}
-        )
-        response.raise_for_status()
-        files = response.json()
-        return files
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                BACKEND_DEV_API_URL, timeout=100, headers={"accept": "application/json"}
+            )
+            response.raise_for_status()
+            files = response.json()
+            return files
+    except httpx.HTTPStatusError as e:
+        logger.error(f"HTTP Status Error: {e}")
+        st.error("ファイル一覧の取得に失敗しました(HTTP Status Error)")
+    except httpx.RequestError as e:
+        logger.error(f"Request Error: {e}")
+        st.error("ファイル一覧の取得に失敗しました(Request Error)")
+    except Exception as e:
+        logger.error(f"Error: {e}")
+        st.error("ファイル一覧の取得に失敗しました(Error)")
+    return []
 
 
 # 非同期でファイル一覧を作成して表示する関数
@@ -55,8 +64,8 @@ async def show_files_list_df() -> None:
     if st.session_state.df is None:
         files = await get_files_list()
         file_df = pd.DataFrame(files)
-        # created_at列をJSTに変換
-        file_df["created_at"] = file_df["created_at"].apply(utc_to_jst)
+        # created_at列の時刻フォーマットを変換
+        file_df["created_at"] = file_df["created_at"].apply(time_format)
         # 新しい boolean 型の列を一番左に追加
         file_df.insert(0, "select", False)
         st.session_state.df = file_df

--- a/frontend/app/pages/select_files.py
+++ b/frontend/app/pages/select_files.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 import os
-import unicodedata
 from datetime import datetime
 
 import httpx
@@ -69,10 +68,6 @@ async def show_files_list_df() -> None:
         file_df.drop(columns=["id", "user_id"], inplace=True)
         # created_at列の時刻フォーマットを変換
         file_df["created_at"] = file_df["created_at"].apply(time_format)
-        # ファイル名列をUnicode正規化(NFC)
-        file_df["file_name"] = file_df["file_name"].apply(
-            lambda x: unicodedata.normalize("NFC", x)
-        )
         # 新しい boolean 型の列を一番左に追加
         file_df.insert(0, "select", False)
         st.session_state.df = file_df

--- a/frontend/app/pages/select_files.py
+++ b/frontend/app/pages/select_files.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import unicodedata
 from datetime import datetime
 
 import httpx
@@ -64,13 +65,28 @@ async def show_files_list_df() -> None:
     if st.session_state.df is None:
         files = await get_files_list()
         file_df = pd.DataFrame(files)
+        # id列, user_id列を削除
+        file_df.drop(columns=["id", "user_id"], inplace=True)
         # created_at列の時刻フォーマットを変換
         file_df["created_at"] = file_df["created_at"].apply(time_format)
+        # ファイル名列をUnicode正規化(NFC)
+        file_df["file_name"] = file_df["file_name"].apply(
+            lambda x: unicodedata.normalize("NFC", x)
+        )
         # 新しい boolean 型の列を一番左に追加
         file_df.insert(0, "select", False)
         st.session_state.df = file_df
     st.data_editor(
-        st.session_state.df, key="changes", on_change=update, hide_index=True
+        st.session_state.df,
+        key="changes",
+        on_change=update,
+        hide_index=True,
+        disabled=("file_name", "file_size", "created_at"),
+        column_config={
+            "file_name": st.column_config.TextColumn(
+                "file_name",
+            )
+        },
     )
 
 
@@ -123,15 +139,16 @@ async def show_select_files_page() -> None:
 
             # 現在のノートタイトルを表示
             st.write(f"Note Title:  {st.session_state.note_name}")
-            st.divider()
 
-        # 学習帳作成ボタン
-        if st.button("学習帳を作成"):
-            st.session_state.selected_files = (
-                selected_files  # 選択されたファイルをセッション状態に保存
-            )
-            st.session_state.page = "pages/study_ai_note.py"  # ページを指定
-            st.switch_page("pages/study_ai_note.py")  # ページに遷移
+            # 学習帳作成ボタン
+            if selected_files and st.session_state.note_name:
+                st.divider()
+                if st.button("学習帳を作成"):
+                    st.session_state.selected_files = (
+                        selected_files  # 選択されたファイルをセッション状態に保存
+                    )
+                    st.session_state.page = "pages/study_ai_note.py"  # ページを指定
+                    st.switch_page("pages/study_ai_note.py")  # ページに遷移
 
     # リセットボタン
     st.divider()
@@ -140,7 +157,7 @@ async def show_select_files_page() -> None:
         st.rerun()
 
 
-# note_nameを更新する関数
+# ノート名を更新する関数
 def update_note_name() -> None:
     st.session_state.note_name = st.session_state.note_input
 

--- a/frontend/app/pages/study_ai_note.py
+++ b/frontend/app/pages/study_ai_note.py
@@ -1,3 +1,4 @@
+# 学習帳ページへの出力サンプルファイル（ノートページへの移植用）
 import asyncio
 import logging
 import os
@@ -5,10 +6,10 @@ import os
 import streamlit as st
 from dotenv import load_dotenv
 
-# streamlitの仕様なのか、相対・絶対インポートでエラーになる。
-# 以下のようにpagesディレクトリ起点ではインポート可能。
-# pytestではパスの読み込みエラーになるため、テストが失敗する。
-from pages.output import create_pdf_to_markdown_summary
+# ユーティリティ関数のインポート
+# Streemlitの仕様なのか、以下の相対パスでインポートする必要がある
+# pytestでテストする際は、エラーが発生する可能性があるため、注意が必要
+from utils.output import create_pdf_to_markdown_summary
 
 # 環境変数を読み込む
 load_dotenv()

--- a/frontend/app/utils/output.py
+++ b/frontend/app/utils/output.py
@@ -1,20 +1,13 @@
+import asyncio
 import logging
-import os
 from typing import AsyncGenerator, List
 
 import httpx
 import streamlit as st
-from dotenv import load_dotenv
 
-# 環境変数を読み込む
-load_dotenv()
-
-# ログの設定
 logging.basicConfig(level=logging.INFO)
 
-# バックエンドAPIのURL
-BACKEND_HOST = os.getenv("BACKEND_HOST")
-BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
+BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
 
 
 async def fetch_gemini_stream_data(filenames: List[str]) -> AsyncGenerator[str, None]:
@@ -33,12 +26,12 @@ async def fetch_gemini_stream_data(filenames: List[str]) -> AsyncGenerator[str, 
     except httpx.RemoteProtocolError as e:
         logging.error(f"通信中にエラーが発生しました: {e}")
         return
-    except httpx.TimeoutException as e:
-        logging.error(f"タイムアウトしました: {e}")
-        st.error(f"タイムアウトしました: {e}")
     except httpx.RequestError as e:
         logging.error(f"リクエストエラーが発生しました: {e}")
         st.error(f"リクエストエラーが発生しました: {e}")
+    except httpx.TimeoutException as e:
+        logging.error(f"タイムアウトしました: {e}")
+        st.error(f"タイムアウトしました: {e}")
     except Exception as e:
         logging.error(f"問題が発生しました: {e}")
         st.error(f"問題が発生しました: {e}")
@@ -54,11 +47,11 @@ async def create_pdf_to_markdown_summary(filenames: List[str]) -> None:
     # await fetch_gemini_stream_data(filenames)
 
 
-# if __name__ == "__main__":
-#     # TODO: 別ページでアップロードされたファイル一覧からファイル名を取得する
-#     # uploaded_filenames = [file.name for file in uploaded_files]
+if __name__ == "__main__":
+    # TODO: 別ページでアップロードされたファイル一覧からファイル名を取得する
+    # uploaded_filenames = [file.name for file in uploaded_files]
 
-#     temp_uploaded_filenames = ["5_アジャイルⅡ.pdf"]
+    temp_uploaded_filenames = ["5_アジャイルⅡ.pdf"]
 
-#     if st.button("要約する"):
-#         asyncio.run(create_pdf_to_markdown_summary(temp_uploaded_filenames))
+    if st.button("要約する"):
+        asyncio.run(create_pdf_to_markdown_summary(temp_uploaded_filenames))

--- a/frontend/app/utils/output.py
+++ b/frontend/app/utils/output.py
@@ -1,13 +1,20 @@
-import asyncio
 import logging
+import os
 from typing import AsyncGenerator, List
 
 import httpx
 import streamlit as st
+from dotenv import load_dotenv
 
+# 環境変数を読み込む
+load_dotenv()
+
+# ログの設定
 logging.basicConfig(level=logging.INFO)
 
-BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
+# バックエンドAPIのURL
+BACKEND_HOST = os.getenv("BACKEND_HOST")
+BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
 
 
 async def fetch_gemini_stream_data(filenames: List[str]) -> AsyncGenerator[str, None]:
@@ -26,12 +33,12 @@ async def fetch_gemini_stream_data(filenames: List[str]) -> AsyncGenerator[str, 
     except httpx.RemoteProtocolError as e:
         logging.error(f"通信中にエラーが発生しました: {e}")
         return
-    except httpx.RequestError as e:
-        logging.error(f"リクエストエラーが発生しました: {e}")
-        st.error(f"リクエストエラーが発生しました: {e}")
     except httpx.TimeoutException as e:
         logging.error(f"タイムアウトしました: {e}")
         st.error(f"タイムアウトしました: {e}")
+    except httpx.RequestError as e:
+        logging.error(f"リクエストエラーが発生しました: {e}")
+        st.error(f"リクエストエラーが発生しました: {e}")
     except Exception as e:
         logging.error(f"問題が発生しました: {e}")
         st.error(f"問題が発生しました: {e}")
@@ -47,11 +54,11 @@ async def create_pdf_to_markdown_summary(filenames: List[str]) -> None:
     # await fetch_gemini_stream_data(filenames)
 
 
-if __name__ == "__main__":
-    # TODO: 別ページでアップロードされたファイル一覧からファイル名を取得する
-    # uploaded_filenames = [file.name for file in uploaded_files]
+# if __name__ == "__main__":
+#     # TODO: 別ページでアップロードされたファイル一覧からファイル名を取得する
+#     # uploaded_filenames = [file.name for file in uploaded_files]
 
-    temp_uploaded_filenames = ["5_アジャイルⅡ.pdf"]
+#     temp_uploaded_filenames = ["5_アジャイルⅡ.pdf"]
 
-    if st.button("要約する"):
-        asyncio.run(create_pdf_to_markdown_summary(temp_uploaded_filenames))
+#     if st.button("要約する"):
+#         asyncio.run(create_pdf_to_markdown_summary(temp_uploaded_filenames))

--- a/frontend/tests/test_output.py
+++ b/frontend/tests/test_output.py
@@ -3,16 +3,25 @@ import httpx
 from unittest.mock import patch, AsyncMock, MagicMock
 from pytest_httpx import HTTPXMock, IteratorStream
 
-from app.pages.output import (
+from app.utils.output import (
     fetch_gemini_stream_data,
     create_pdf_to_markdown_summary,
 )
+from dotenv import load_dotenv
+import os
+
+# 環境変数を読み込む
+load_dotenv()
 
 
+# バックエンドAPIのURL
+BACKEND_HOST = os.getenv("BACKEND_HOST")
+
+
+# 正常系のテスト(テストデータを返す)
 @pytest.mark.asyncio
 async def test_fetch_gemini_stream_data(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
-
+    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
     filenames = ["test.pdf"]
     httpx_mock.add_response(
         method="POST",
@@ -29,9 +38,10 @@ async def test_fetch_gemini_stream_data(httpx_mock: HTTPXMock) -> None:
             assert [part async for part in response.aiter_raw()] == [b"*Test Output*"]
 
 
+# 正常系のテスト(テストデータを返す)
 @pytest.mark.asyncio
 async def test_fetch_gemini_stream_data_success(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
+    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
     filenames = ["test.pdf"]
 
     httpx_mock.add_response(
@@ -50,9 +60,10 @@ async def test_fetch_gemini_stream_data_success(httpx_mock: HTTPXMock) -> None:
     assert data == ["chunk1", "chunk2"]
 
 
+# 異常系のテスト(HTTPステータスエラー)
 @pytest.mark.asyncio
 async def test_fetch_gemini_stream_data_http_error(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
+    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
     filenames = ["test.pdf"]
 
     httpx_mock.add_exception(
@@ -77,11 +88,12 @@ async def test_fetch_gemini_stream_data_http_error(httpx_mock: HTTPXMock) -> Non
                 pass
 
 
+# 異常系のテスト(リモートプロトコルエラー)
 @pytest.mark.asyncio
 async def test_fetch_gemini_stream_data_remote_protocol_error(
     httpx_mock: HTTPXMock,
 ) -> None:
-    BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
+    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
     filenames = ["test.pdf"]
 
     httpx_mock.add_exception(
@@ -105,9 +117,10 @@ async def test_fetch_gemini_stream_data_remote_protocol_error(
                 pass
 
 
+# 異常系のテスト(リクエストエラー)
 @pytest.mark.asyncio
 async def test_fetch_gemini_stream_data_request_error(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
+    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
     filenames = ["test.pdf"]
 
     httpx_mock.add_exception(
@@ -131,9 +144,10 @@ async def test_fetch_gemini_stream_data_request_error(httpx_mock: HTTPXMock) -> 
                 pass
 
 
+# 異常系のテスト(タイムアウトエラー)
 @pytest.mark.asyncio
 async def test_fetch_gemini_stream_data_timeout_error(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
+    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
     filenames = ["test.pdf"]
 
     httpx_mock.add_exception(
@@ -157,9 +171,10 @@ async def test_fetch_gemini_stream_data_timeout_error(httpx_mock: HTTPXMock) -> 
                 pass
 
 
+# 異常系のテスト(例外エラー)
 @pytest.mark.asyncio
 async def test_fetch_gemini_stream_data_exception_error(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
+    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
     filenames = ["test.pdf"]
 
     httpx_mock.add_exception(
@@ -174,9 +189,10 @@ async def test_fetch_gemini_stream_data_exception_error(httpx_mock: HTTPXMock) -
                 pass
 
 
+# 正常系のテスト(テストデータを返す)
 @pytest.mark.asyncio
 async def test_create_pdf_to_markdown_summary(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
+    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
     filenames = ["test.pdf"]
 
     httpx_mock.add_response(

--- a/frontend/tests/test_output.py
+++ b/frontend/tests/test_output.py
@@ -7,21 +7,12 @@ from app.utils.output import (
     fetch_gemini_stream_data,
     create_pdf_to_markdown_summary,
 )
-from dotenv import load_dotenv
-import os
-
-# 環境変数を読み込む
-load_dotenv()
 
 
-# バックエンドAPIのURL
-BACKEND_HOST = os.getenv("BACKEND_HOST")
-
-
-# 正常系のテスト(テストデータを返す)
 @pytest.mark.asyncio
 async def test_fetch_gemini_stream_data(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
+    BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
+
     filenames = ["test.pdf"]
     httpx_mock.add_response(
         method="POST",
@@ -38,10 +29,9 @@ async def test_fetch_gemini_stream_data(httpx_mock: HTTPXMock) -> None:
             assert [part async for part in response.aiter_raw()] == [b"*Test Output*"]
 
 
-# 正常系のテスト(テストデータを返す)
 @pytest.mark.asyncio
 async def test_fetch_gemini_stream_data_success(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
+    BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
     filenames = ["test.pdf"]
 
     httpx_mock.add_response(
@@ -60,10 +50,9 @@ async def test_fetch_gemini_stream_data_success(httpx_mock: HTTPXMock) -> None:
     assert data == ["chunk1", "chunk2"]
 
 
-# 異常系のテスト(HTTPステータスエラー)
 @pytest.mark.asyncio
 async def test_fetch_gemini_stream_data_http_error(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
+    BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
     filenames = ["test.pdf"]
 
     httpx_mock.add_exception(
@@ -88,12 +77,11 @@ async def test_fetch_gemini_stream_data_http_error(httpx_mock: HTTPXMock) -> Non
                 pass
 
 
-# 異常系のテスト(リモートプロトコルエラー)
 @pytest.mark.asyncio
 async def test_fetch_gemini_stream_data_remote_protocol_error(
     httpx_mock: HTTPXMock,
 ) -> None:
-    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
+    BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
     filenames = ["test.pdf"]
 
     httpx_mock.add_exception(
@@ -117,10 +105,9 @@ async def test_fetch_gemini_stream_data_remote_protocol_error(
                 pass
 
 
-# 異常系のテスト(リクエストエラー)
 @pytest.mark.asyncio
 async def test_fetch_gemini_stream_data_request_error(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
+    BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
     filenames = ["test.pdf"]
 
     httpx_mock.add_exception(
@@ -144,10 +131,9 @@ async def test_fetch_gemini_stream_data_request_error(httpx_mock: HTTPXMock) -> 
                 pass
 
 
-# 異常系のテスト(タイムアウトエラー)
 @pytest.mark.asyncio
 async def test_fetch_gemini_stream_data_timeout_error(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
+    BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
     filenames = ["test.pdf"]
 
     httpx_mock.add_exception(
@@ -171,10 +157,9 @@ async def test_fetch_gemini_stream_data_timeout_error(httpx_mock: HTTPXMock) -> 
                 pass
 
 
-# 異常系のテスト(例外エラー)
 @pytest.mark.asyncio
 async def test_fetch_gemini_stream_data_exception_error(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
+    BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
     filenames = ["test.pdf"]
 
     httpx_mock.add_exception(
@@ -189,10 +174,9 @@ async def test_fetch_gemini_stream_data_exception_error(httpx_mock: HTTPXMock) -
                 pass
 
 
-# 正常系のテスト(テストデータを返す)
 @pytest.mark.asyncio
 async def test_create_pdf_to_markdown_summary(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
+    BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
     filenames = ["test.pdf"]
 
     httpx_mock.add_response(


### PR DESCRIPTION
## Issue No.
#78 

## 影響範囲とその理由
output.pyをpagesからutilsディレクトリに移動したため、インポートする際はパスの変更が必要です。
study_ai_note.pyファイルは、出力先のサンプルとしてのファイルのため、別のノートファイルに統合したら削除予定です。
（このファイルのテストは実施してません。）

## チェックリスト
<!-- 変更を行った際にチェックした項目にチェックを入れてください。 -->
- [x] 単体テストを実施した
- [ ] 統合テストを実施した
- [ ] ドキュメントを更新した

## スクリーンショット
<!-- UIの変更がある場合は、Before / Afterのスクリーンショットや動作が分かるGIFなどを添付してください。 -->
https://drive.google.com/file/d/1IbekDXEXAf8P0laI5_9rCtN199hZGpMh/view?usp=sharing

## レビュアーに確認してほしいこと 
- docker compose upでコンテナを立ち上げて、loclhost:8501でselect filesページを開いて、動画の動作が再現されること。
- pytestでエラーがでないこと。

## 関連リンク
<!-- ソースコードに関連するファイルがあればリンクを共有 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - 日本語ファイル名のNFC正規化を追加し、ファイルアップロード処理の一貫性を向上。

- **リファクタリング**
  - 日付および時刻関連の関数をリファクタリングし、`timezone`モジュールの使用を削除。
  - エラーハンドリングおよびログ記録の強化。
  - インポートパスの修正により、Streamlitおよびpytestの潜在的なエラーを修正。

- **テスト**
  - ファイル名のNFC正規化を検証する新しいテストを追加。
  - 環境変数の読み込みと設定に関するテストを追加し、異常シナリオを含むテストカバレッジを拡大。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->