### PR TITLE
フロントエンド：output.pyのBACKEND HOSTを.envから呼び出す

### DIFF
--- a/frontend/app/utils/output.py
+++ b/frontend/app/utils/output.py
@@ -1,13 +1,18 @@
 import asyncio
 import logging
+import os
 from typing import AsyncGenerator, List
 
 import httpx
 import streamlit as st
+from dotenv import find_dotenv, load_dotenv
+
+load_dotenv(find_dotenv())
 
 logging.basicConfig(level=logging.INFO)
 
-BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
+BACKEND_HOST = os.getenv("BACKEND_DEV_HOST")
+BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream/"
 
 
 async def fetch_gemini_stream_data(filenames: List[str]) -> AsyncGenerator[str, None]:

--- a/frontend/tests/test_output.py
+++ b/frontend/tests/test_output.py
@@ -2,6 +2,8 @@ import pytest
 import httpx
 from unittest.mock import patch, AsyncMock, MagicMock
 from pytest_httpx import HTTPXMock, IteratorStream
+import os
+from dotenv import load_dotenv
 
 from app.utils.output import (
     fetch_gemini_stream_data,
@@ -9,9 +11,14 @@ from app.utils.output import (
 )
 
 
+load_dotenv()
+
+BACKEND_HOST = os.getenv("BACKEND_DEV_HOST")
+
+
 @pytest.mark.asyncio
 async def test_fetch_gemini_stream_data(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
+    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream/"
 
     filenames = ["test.pdf"]
     httpx_mock.add_response(
@@ -31,7 +38,7 @@ async def test_fetch_gemini_stream_data(httpx_mock: HTTPXMock) -> None:
 
 @pytest.mark.asyncio
 async def test_fetch_gemini_stream_data_success(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
+    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream/"
     filenames = ["test.pdf"]
 
     httpx_mock.add_response(
@@ -52,7 +59,7 @@ async def test_fetch_gemini_stream_data_success(httpx_mock: HTTPXMock) -> None:
 
 @pytest.mark.asyncio
 async def test_fetch_gemini_stream_data_http_error(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
+    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream/"
     filenames = ["test.pdf"]
 
     httpx_mock.add_exception(
@@ -81,7 +88,7 @@ async def test_fetch_gemini_stream_data_http_error(httpx_mock: HTTPXMock) -> Non
 async def test_fetch_gemini_stream_data_remote_protocol_error(
     httpx_mock: HTTPXMock,
 ) -> None:
-    BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
+    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream/"
     filenames = ["test.pdf"]
 
     httpx_mock.add_exception(
@@ -107,7 +114,7 @@ async def test_fetch_gemini_stream_data_remote_protocol_error(
 
 @pytest.mark.asyncio
 async def test_fetch_gemini_stream_data_request_error(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
+    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream/"
     filenames = ["test.pdf"]
 
     httpx_mock.add_exception(
@@ -133,7 +140,7 @@ async def test_fetch_gemini_stream_data_request_error(httpx_mock: HTTPXMock) -> 
 
 @pytest.mark.asyncio
 async def test_fetch_gemini_stream_data_timeout_error(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
+    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream/"
     filenames = ["test.pdf"]
 
     httpx_mock.add_exception(
@@ -159,7 +166,7 @@ async def test_fetch_gemini_stream_data_timeout_error(httpx_mock: HTTPXMock) -> 
 
 @pytest.mark.asyncio
 async def test_fetch_gemini_stream_data_exception_error(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
+    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream/"
     filenames = ["test.pdf"]
 
     httpx_mock.add_exception(
@@ -176,7 +183,7 @@ async def test_fetch_gemini_stream_data_exception_error(httpx_mock: HTTPXMock) -
 
 @pytest.mark.asyncio
 async def test_create_pdf_to_markdown_summary(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = "http://ai-notebook-backend-1:8000/outputs/request_stream"
+    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream/"
     filenames = ["test.pdf"]
 
     httpx_mock.add_response(


### PR DESCRIPTION
## Issue No.
n/a

## 影響範囲とその理由
<!-- この変更により起こり得る影響範囲とその理由を書いてください。 -->

- output.pyのBACKENDのホストを.envファイルから呼び出すようにUpdate
- あわせてテストファイルも編集

## チェックリスト
<!-- 変更を行った際にチェックした項目にチェックを入れてください。 -->
- [x] 単体テストを実施した
- [ ] 統合テストを実施した
- [ ] ドキュメントを更新した

## スクリーンショット
<!-- UIの変更がある場合は、Before / Afterのスクリーンショットや動作が分かるGIFなどを添付してください。 -->
n/a

## レビュアーに確認してほしいこと 
<!-- テストや事象の再現が必要な場合、レビュアーが再現できる実施手順を必ず明記してください！ -->
<!-- レビュワーに特に注目してほしいポイントや、不安な部分があれば明記してください。 -->
CI通ってるいるのでPytestは通ると思います。


## 関連リンク
<!-- ソースコードに関連するファイルがあればリンクを共有 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 環境変数を使用してバックエンドホストを設定できるようになり、設定の柔軟性が向上しました。

- **テスト**
  - 環境変数を読み込み、テストで使用するバックエンドホストURLを動的に構築するよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->