### PR TITLE
(フロントエンド)fix backend api url

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,5 @@
-BACKEND_HOST=http://localhost:8000
-BACKEND_DEV_HOST=http://localhost:8000
+BACKEND_HOST=http://backend:8000
+BACKEND_DEV_HOST=http://backend:8000
 
 # Development database settings
 DB_USER=root

--- a/frontend/app/utils/output.py
+++ b/frontend/app/utils/output.py
@@ -12,7 +12,7 @@ load_dotenv(find_dotenv())
 logging.basicConfig(level=logging.INFO)
 
 BACKEND_HOST = os.getenv("BACKEND_DEV_HOST")
-BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream/"
+BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
 
 
 async def fetch_gemini_stream_data(filenames: List[str]) -> AsyncGenerator[str, None]:

--- a/frontend/tests/test_output.py
+++ b/frontend/tests/test_output.py
@@ -18,7 +18,7 @@ BACKEND_HOST = os.getenv("BACKEND_DEV_HOST")
 
 @pytest.mark.asyncio
 async def test_fetch_gemini_stream_data(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream/"
+    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
 
     filenames = ["test.pdf"]
     httpx_mock.add_response(
@@ -38,7 +38,7 @@ async def test_fetch_gemini_stream_data(httpx_mock: HTTPXMock) -> None:
 
 @pytest.mark.asyncio
 async def test_fetch_gemini_stream_data_success(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream/"
+    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
     filenames = ["test.pdf"]
 
     httpx_mock.add_response(
@@ -59,7 +59,7 @@ async def test_fetch_gemini_stream_data_success(httpx_mock: HTTPXMock) -> None:
 
 @pytest.mark.asyncio
 async def test_fetch_gemini_stream_data_http_error(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream/"
+    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
     filenames = ["test.pdf"]
 
     httpx_mock.add_exception(
@@ -88,7 +88,7 @@ async def test_fetch_gemini_stream_data_http_error(httpx_mock: HTTPXMock) -> Non
 async def test_fetch_gemini_stream_data_remote_protocol_error(
     httpx_mock: HTTPXMock,
 ) -> None:
-    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream/"
+    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
     filenames = ["test.pdf"]
 
     httpx_mock.add_exception(
@@ -114,7 +114,7 @@ async def test_fetch_gemini_stream_data_remote_protocol_error(
 
 @pytest.mark.asyncio
 async def test_fetch_gemini_stream_data_request_error(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream/"
+    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
     filenames = ["test.pdf"]
 
     httpx_mock.add_exception(
@@ -140,7 +140,7 @@ async def test_fetch_gemini_stream_data_request_error(httpx_mock: HTTPXMock) -> 
 
 @pytest.mark.asyncio
 async def test_fetch_gemini_stream_data_timeout_error(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream/"
+    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
     filenames = ["test.pdf"]
 
     httpx_mock.add_exception(
@@ -166,7 +166,7 @@ async def test_fetch_gemini_stream_data_timeout_error(httpx_mock: HTTPXMock) -> 
 
 @pytest.mark.asyncio
 async def test_fetch_gemini_stream_data_exception_error(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream/"
+    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
     filenames = ["test.pdf"]
 
     httpx_mock.add_exception(
@@ -183,7 +183,7 @@ async def test_fetch_gemini_stream_data_exception_error(httpx_mock: HTTPXMock) -
 
 @pytest.mark.asyncio
 async def test_create_pdf_to_markdown_summary(httpx_mock: HTTPXMock) -> None:
-    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream/"
+    BACKEND_DEV_API_URL = f"{BACKEND_HOST}/outputs/request_stream"
     filenames = ["test.pdf"]
 
     httpx_mock.add_response(


### PR DESCRIPTION
## Issue No.
対応なし

## 影響範囲とその理由
backend urlをf"{BACKEND_HOST}/outputs/request_stream/"からf"{BACKEND_HOST}/outputs/request_stream"に修正
→アクセスが可能に

## チェックリスト
<!-- 変更を行った際にチェックした項目にチェックを入れてください。 -->
- [X] 単体テストを実施した
- [ ] 統合テストを実施した
- [ ] ドキュメントを更新した

## スクリーンショット
<!-- UIの変更がある場合は、Before / Afterのスクリーンショットや動作が分かるGIFなどを添付してください。 -->

## レビュアーに確認してほしいこと 
<!-- テストや事象の再現が必要な場合、レビュアーが再現できる実施手順を必ず明記してください！ -->
<!-- レビュワーに特に注目してほしいポイントや、不安な部分があれば明記してください。 -->

## 関連リンク
<!-- ソースコードに関連するファイルがあればリンクを共有 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 環境設定ファイルのバックエンドURLの修正を行い、`http://localhost:8000`から`http://backend:8000`に変更しました。
  - API URLの末尾のスラッシュを削除してURL構築の整合性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->