### PR TITLE
フロントエンドのサイドバー修正、共通化 #25

### DIFF
--- a/frontend/.streamlit/config.toml
+++ b/frontend/.streamlit/config.toml
@@ -1,6 +1,7 @@
+[client]
+showSidebarNavigation = false
 [server]
 maxUploadSize = 200
-showSidebarNavigation = false
+runOnSave = true
 [theme]
-sidebarEnabled = false
 primaryColor = "#0000FF"

--- a/frontend/app/main.py
+++ b/frontend/app/main.py
@@ -14,6 +14,7 @@ import requests  # type: ignore
 import streamlit as st
 from dotenv import load_dotenv
 from PIL import Image
+from utils.sidebar import show_sidebar
 
 # 環境変数を読み込む
 load_dotenv()
@@ -21,14 +22,6 @@ load_dotenv()
 BACKEND_HOST = os.getenv("BACKEND_HOST")
 
 IMG_PATH = "imgs"
-
-with st.sidebar:
-    st.page_link("main.py", label="ホーム", icon="🏠")
-    st.page_link("pages/upload_image.py", label="ファイルアップロード", icon="1️⃣")
-    st.page_link("pages/input_text.py", label="テキスト入力", icon="2️⃣")
-    st.page_link("pages/output_note.py", label="AIサポート学習帳", icon="3️⃣")
-    st.page_link("pages/output_test.py", label="AIサポートテスト", icon="4️⃣")
-    st.page_link("pages/flyer.py", label="PBL フライヤー")
 
 
 def upload_files() -> None:
@@ -66,4 +59,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    show_sidebar()
     main()

--- a/frontend/app/pages/flyer.py
+++ b/frontend/app/pages/flyer.py
@@ -8,26 +8,21 @@
 ##ファイルタイプを'png', 'pdf', 'jpeg', 'jpg'に制限する
 ##ファイルサイズは‘.streamlit/config.toml’で変更（デフォルト200MB）
 
-from ast import main
+# from ast import main
 
-import streamlit as st
-from PIL import Image
+# import streamlit as st
+from utils.sidebar import show_sidebar
 
-IMG_PATH = 'imgs'
+# from PIL import Image
+
+IMG_PATH = "imgs"
 #
-with st.sidebar:
-    st.page_link("main.py", label="ホーム", icon="🏠")
-    st.page_link("pages/upload_image.py", label="ファイルアップロード", icon="1️⃣")
-    st.page_link("pages/input_text.py", label="テキスト入力", icon="2️⃣")
-    st.page_link("pages/output_note.py", label="AIサポート学習帳", icon="3️⃣")
-    st.page_link("pages/output_test.py", label="AIサポートテスト", icon="4️⃣")
-    st.page_link("pages/flyer.py", label="PBL フライヤー")
 
+# img = Image.open("PBLフライヤー1Q.jpg")
+# use_column_width 実際のレイアウトの横幅に合わせるか
+# st.image(img, caption='AIサポート学習帳', use_column_width=True)
+# st.image(img, use_column_width=True)
 
-    img = Image.open('PBLフライヤー1Q.jpg')
-    # use_column_width 実際のレイアウトの横幅に合わせるか
-    #st.image(img, caption='AIサポート学習帳', use_column_width=True)
-    st.image(img, use_column_width=True)
-
-if __name__ == '__main__':
-    main()
+if __name__ == "__main__":
+    show_sidebar()
+    # main()

--- a/frontend/app/pages/input_text.py
+++ b/frontend/app/pages/input_text.py
@@ -10,16 +10,9 @@
 
 
 import streamlit as st
+from utils.sidebar import show_sidebar
 
 IMG_PATH = "imgs"
-
-with st.sidebar:
-    st.page_link("main.py", label="ホーム", icon="🏠")
-    st.page_link("pages/upload_image.py", label="ファイルアップロード", icon="1️⃣")
-    st.page_link("pages/input_text.py", label="テキスト入力", icon="2️⃣")
-    st.page_link("pages/output_note.py", label="AIサポート学習帳", icon="3️⃣")
-    st.page_link("pages/output_test.py", label="AIサポートテスト", icon="4️⃣")
-    st.page_link("pages/flyer.py", label="PBL フライヤー")
 
 
 def main() -> None:
@@ -41,4 +34,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    show_sidebar()
     main()

--- a/frontend/app/pages/output_note.py
+++ b/frontend/app/pages/output_note.py
@@ -10,16 +10,9 @@
 
 
 import streamlit as st
+from utils.sidebar import show_sidebar
 
 IMG_PATH = "imgs"
-
-with st.sidebar:
-    st.page_link("main.py", label="ホーム", icon="🏠")
-    st.page_link("pages/upload_image.py", label="ファイルアップロード", icon="1️⃣")
-    st.page_link("pages/input_text.py", label="テキスト入力", icon="2️⃣")
-    st.page_link("pages/output_note.py", label="AIサポート学習帳", icon="3️⃣")
-    st.page_link("pages/output_test.py", label="AIサポートテスト", icon="4️⃣")
-    st.page_link("pages/flyer.py", label="PBL フライヤー")
 
 
 def main() -> None:
@@ -41,4 +34,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    show_sidebar()
     main()

--- a/frontend/app/pages/output_test.py
+++ b/frontend/app/pages/output_test.py
@@ -10,16 +10,9 @@
 
 
 import streamlit as st
+from utils.sidebar import show_sidebar
 
 IMG_PATH = "imgs"
-
-with st.sidebar:
-    st.page_link("main.py", label="ホーム", icon="🏠")
-    st.page_link("pages/upload_image.py", label="ファイルアップロード", icon="1️⃣")
-    st.page_link("pages/input_text.py", label="テキスト入力", icon="2️⃣")
-    st.page_link("pages/output_note.py", label="AIサポート学習帳", icon="3️⃣")
-    st.page_link("pages/output_test.py", label="AIサポートテスト", icon="4️⃣")
-    st.page_link("pages/flyer.py", label="PBL フライヤー")
 
 
 def main() -> None:
@@ -41,4 +34,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    show_sidebar()
     main()

--- a/frontend/app/pages/select_files.py
+++ b/frontend/app/pages/select_files.py
@@ -7,6 +7,7 @@ import httpx
 import pandas as pd
 import streamlit as st
 from dotenv import load_dotenv
+from utils.sidebar import show_sidebar
 
 # 環境変数を読み込む
 load_dotenv()
@@ -212,4 +213,5 @@ def update_note_name() -> None:
 
 # ファイル選択ページの処理を実行
 if __name__ == "__main__":
+    show_sidebar()
     asyncio.run(show_select_files_page())

--- a/frontend/app/pages/select_files.py
+++ b/frontend/app/pages/select_files.py
@@ -1,13 +1,20 @@
 import asyncio
 import logging
 import os
+import sys
 from datetime import datetime
 
 import httpx
 import pandas as pd
 import streamlit as st
 from dotenv import load_dotenv
-from utils.sidebar import show_sidebar
+
+# プロジェクトルートのパスを取得
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+# プロジェクトルートをPythonパスに追加
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
 
 # 環境変数を読み込む
 load_dotenv()
@@ -143,7 +150,7 @@ async def show_select_files_page() -> None:
 
     :return: None
     """
-    st.set_page_config(layout="wide")
+    # st.set_page_config(layout="wide")
     st.session_state.page = "pages/select_files.py"
     st.header("AIノートを作成", divider="blue")
 
@@ -213,5 +220,7 @@ def update_note_name() -> None:
 
 # ファイル選択ページの処理を実行
 if __name__ == "__main__":
+    from app.utils.sidebar import show_sidebar
+
     show_sidebar()
     asyncio.run(show_select_files_page())

--- a/frontend/app/pages/study_ai_note.py
+++ b/frontend/app/pages/study_ai_note.py
@@ -82,4 +82,7 @@ def create_study_ai_note(selected_files: list) -> str | None:
 
 
 if __name__ == "__main__":
+    from app.utils.sidebar import show_sidebar
+
+    show_sidebar()
     show_output_page()

--- a/frontend/app/pages/upload_image.py
+++ b/frontend/app/pages/upload_image.py
@@ -10,19 +10,13 @@
 
 
 import streamlit as st
+from utils.sidebar import show_sidebar
 
 IMG_PATH = "imgs"
 
-with st.sidebar:
-    st.page_link("main.py", label="ホーム", icon="🏠")
-    st.page_link("pages/upload_image.py", label="ファイルアップロード", icon="1️⃣")
-    st.page_link("pages/input_text.py", label="テキスト入力", icon="2️⃣")
-    st.page_link("pages/output_note.py", label="AIサポート学習帳", icon="3️⃣")
-    st.page_link("pages/output_test.py", label="AIサポートテスト", icon="4️⃣")
-    st.page_link("pages/flyer.py", label="PBL フライヤー")
-
 
 def main() -> None:
+    show_sidebar()
     st.markdown("# AIサポート学習帳")
     file = st.file_uploader(
         "講義テキストの画像をアップロードしてください.（アプロード可能なファイルタイプ：png,pdf,jpeg,jpg）",

--- a/frontend/app/utils/sidebar.py
+++ b/frontend/app/utils/sidebar.py
@@ -1,0 +1,12 @@
+import streamlit as st
+
+
+def show_sidebar() -> None:
+    with st.sidebar:
+        st.page_link("main.py", label="ホーム", icon="🏠")
+        st.page_link("pages/select_files.py", label="ファイル選択", icon="📁")
+        st.page_link("pages/study_ai_note.py", label="AI出力", icon="🗒️")
+        # st.page_link("pages/upload_image.py", label="ファイルアップロード"")
+        # st.page_link("pages/input_text.py", label="テキスト入力", icon="")
+        # st.page_link("pages/output_note.py", label="AIサポート学習帳", icon="")
+        # st.page_link("pages/output_test.py", label="AIサポートテスト", icon="")

--- a/frontend/tests/test_select_files.py
+++ b/frontend/tests/test_select_files.py
@@ -11,8 +11,11 @@ from app.pages.select_files import (
 )
 import streamlit as st
 import pandas as pd
-import logging
+
+
 import httpx
+import logging
+
 from streamlit.testing.v1 import AppTest
 
 # ストリームリットのエラーメッセージをモック
@@ -315,7 +318,7 @@ async def test_show_select_files_page() -> None:
     """
     :概要: show_select_files_page関数のテストを行います。
 
-    :詳細: 
+    :詳細:
         - 初期状態の確認
         - "ファイル一覧を取得"ボタンのクリック
         - セッション状態の更新
@@ -325,7 +328,8 @@ async def test_show_select_files_page() -> None:
         - ページ遷移の確認
     """
     # テスト用のAppTestインスタンスを作成
-    at = AppTest.from_file("app/pages/select_files.py")
+    at = AppTest.from_file("app/main.py").run()
+    at.switch_page("pages/select_files.py").run()
 
     # アプリを実行
     at.run()
@@ -422,7 +426,7 @@ async def test_reset_button() -> None:
     """
     :概要: リセットボタンのテストを行います。
 
-    :詳細: 
+    :詳細:
         - 初期状態の確認
         - "ファイル一覧を取得"ボタンのクリック
         - セッション状態の更新
@@ -430,7 +434,9 @@ async def test_reset_button() -> None:
         - 入力がリセットされたことを確認
     """
     # テスト用のAppTestインスタンスを作成
-    at = AppTest.from_file("app/pages/select_files.py")
+    at = AppTest.from_file("app/main.py").run()
+    at.switch_page("pages/select_files.py").run()
+    # at = AppTest.from_file("app/pages/select_files.py")
 
     # アプリを実行
     at.run()
@@ -459,4 +465,3 @@ async def test_reset_button() -> None:
     # 入力がリセットされたことを確認
     assert at.session_state["note_name"] == ""
     assert at.session_state["selected_files"] == []
-


### PR DESCRIPTION
## Issue No.
#104 

## 影響範囲とその理由
<!-- この変更により起こり得る影響範囲とその理由を書いてください。 -->
- sidebarのファイルを作成しました
- pages/ 配下のファイルにあったサイドバーの重複コードを削除しました
- sidebar.pyを読み込むようにしました。
- それに伴い、一部Pytestで発生していたエラーを解消するためテストコードを修正しました
- それに伴い、更新されていないページをサイドバーから削除し、モックアップに合わせました

## チェックリスト
<!-- 変更を行った際にチェックした項目にチェックを入れてください。 -->
- [x] 単体テストを実施した
- [ ] 統合テストを実施した
- [ ] ドキュメントを更新した

## スクリーンショット
<!-- UIの変更がある場合は、Before / Afterのスクリーンショットや動作が分かるGIFなどを添付してください。 -->
<img width="502" alt="image" src="https://github.com/AIIT-Oikawa-PBL-2024/AI-Notebook/assets/56593880/2a868aab-3024-4815-b274-3ec8c4e09f6a">

## レビュアーに確認してほしいこと 
<!-- テストや事象の再現が必要な場合、レビュアーが再現できる実施手順を必ず明記してください！ -->
<!-- レビュワーに特に注目してほしいポイントや、不安な部分があれば明記してください。 -->
- テストコードが通ること（念の為）
- UI上の不具合がないこと

## 関連リンク
<!-- ソースコードに関連するファイルがあればリンクを共有 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - サイドバーリンクを表示する新しい関数 `show_sidebar()` を追加しました。

- **改善**
  - サイドバーリンクを個別に定義する代わりに `show_sidebar()` 関数を使用するように変更しました。
  - サーバー設定に `runOnSave = true` を追加しました。

- **バグ修正**
  - 複数のファイルでサイドバーリンクの定義を削除し、`show_sidebar()` を使用するように修正しました。

- **テスト**
  - テストファイルのインポート文とインスタンス生成に関連する修正を行いました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->