### PR TITLE
 バックエンドでストレージの削除機能実装

### DIFF
--- a/backend/app/cruds/files.py
+++ b/backend/app/cruds/files.py
@@ -69,12 +69,15 @@ async def delete_file_by_name_and_userid(
     :return: None
     :rtype: None
     """
-    result: Result = await db.execute(
-        select(files_models.File)
-        .filter(files_models.File.file_name == file_name)
-        .filter(files_models.File.user_id == user_id)
-    )
-    for file in result.scalars():
-        await db.delete(file)
+    try:
+        result: Result = await db.execute(
+            select(files_models.File)
+            .filter(files_models.File.file_name == file_name)
+            .filter(files_models.File.user_id == user_id)
+        )
+        for file in result.scalars():
+            await db.delete(file)
         await db.commit()
-    return
+    except Exception as e:
+        await db.rollback()
+        raise e

--- a/backend/app/cruds/files.py
+++ b/backend/app/cruds/files.py
@@ -107,3 +107,4 @@ async def delete_file_by_name_and_userid(
     except Exception as e:
         await db.rollback()
         raise e
+        

--- a/backend/app/cruds/files.py
+++ b/backend/app/cruds/files.py
@@ -107,4 +107,3 @@ async def delete_file_by_name_and_userid(
     except Exception as e:
         await db.rollback()
         raise e
-        

--- a/backend/app/cruds/files.py
+++ b/backend/app/cruds/files.py
@@ -58,7 +58,7 @@ async def delete_file_by_name_and_userid(
     db: AsyncSession, file_name: str, user_id: int
 ) -> None:
     """
-    指定されたファイル名とユーザーIDに一致するファイルを削除します。
+    指定されたファイル名とユーザーIDに基づいてファイルを削除します。
 
     :param db: データベースセッション
     :type db: AsyncSession
@@ -74,7 +74,7 @@ async def delete_file_by_name_and_userid(
         .filter(files_models.File.file_name == file_name)
         .filter(files_models.File.user_id == user_id)
     )
-    file = result.scalars().first()
-    await db.delete(file)
-    await db.commit()
+    for file in result.scalars():
+        await db.delete(file)
+        await db.commit()
     return

--- a/backend/app/cruds/files.py
+++ b/backend/app/cruds/files.py
@@ -53,30 +53,28 @@ async def get_file_by_id(db: AsyncSession, file_id: int) -> files_models.File | 
     return result.scalars().first()  # 結果の最初のファイルを返す
 
 
-# ファイルIDから特定のファイルを削除する関数
-async def delete_file(db: AsyncSession, original_file: files_models.File) -> None:
-    await db.delete(original_file)  # ファイルを削除
-    await db.commit()  # 変更をコミット
-    return
-
-
-# ファイル名から特定のファイルを削除する関数
-async def delete_file_by_name(db: AsyncSession, file_name: str) -> None:
+# ファイル名とユーザーIDから特定のファイルを削除する関数
+async def delete_file_by_name_and_userid(
+    db: AsyncSession, file_name: str, user_id: int
+) -> None:
     """
-    ファイル名を指定してファイルを削除します。
+    指定されたファイル名とユーザーIDに一致するファイルを削除します。
 
     :param db: データベースセッション
     :type db: AsyncSession
     :param file_name: 削除するファイルの名前
     :type file_name: str
+    :param user_id: ファイルを所有するユーザーのID
+    :type user_id: int
     :return: None
+    :rtype: None
     """
-    # 指定されたファイル名のファイル情報を選択
     result: Result = await db.execute(
-        select(files_models.File).filter(files_models.File.file_name == file_name)
+        select(files_models.File)
+        .filter(files_models.File.file_name == file_name)
+        .filter(files_models.File.user_id == user_id)
     )
-    file = result.scalars().first()  # 結果の最初のファイルを取得
-    if file:
-        await db.delete(file)  # ファイルを削除
-        await db.commit()  # 変更をコミット
+    file = result.scalars().first()
+    await db.delete(file)
+    await db.commit()
     return

--- a/backend/app/cruds/files.py
+++ b/backend/app/cruds/files.py
@@ -58,3 +58,25 @@ async def delete_file(db: AsyncSession, original_file: files_models.File) -> Non
     await db.delete(original_file)  # ファイルを削除
     await db.commit()  # 変更をコミット
     return
+
+
+# ファイル名から特定のファイルを削除する関数
+async def delete_file_by_name(db: AsyncSession, file_name: str) -> None:
+    """
+    ファイル名を指定してファイルを削除します。
+
+    :param db: データベースセッション
+    :type db: AsyncSession
+    :param file_name: 削除するファイルの名前
+    :type file_name: str
+    :return: None
+    """
+    # 指定されたファイル名のファイル情報を選択
+    result: Result = await db.execute(
+        select(files_models.File).filter(files_models.File.file_name == file_name)
+    )
+    file = result.scalars().first()  # 結果の最初のファイルを取得
+    if file:
+        await db.delete(file)  # ファイルを削除
+        await db.commit()  # 変更をコミット
+    return

--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -109,9 +109,18 @@ async def delete_files(
     :return: 削除結果の辞書
     :rtype: dict
     """
-    # ファイルをDBから削除
-    for file_name in files:
-        await files_cruds.delete_file_by_name_and_userid(db, file_name, user_id)
+    try:
+        # ファイルをDBから削除
+        for file_name in files:
+            await files_cruds.delete_file_by_name_and_userid(db, file_name, user_id)
+
+        await db.commit()
+    except Exception as e:
+        await db.rollback()
+        raise HTTPException(
+            status_code=500,
+            detail=f"{file_name} ファイルの削除に失敗しました",
+        ) from e
 
     # ファイルをGoogle Cloud Storageから削除
     response_data = {}

--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -100,3 +100,23 @@ async def delete_file(file_id: int, db: AsyncSession = db_dependency) -> dict:
         raise HTTPException(status_code=404, detail="ファイルが見つかりません")
     await files_cruds.delete_file(db, file)
     return {"detail": "ファイルが削除されました"}
+
+
+# ファイル名のリストによるファイルの削除
+@router.delete("/delete_files", response_model=dict)
+async def delete_files_by_name(
+    files: list[str], db: AsyncSession = db_dependency
+) -> dict:
+    """
+    ファイル名を指定してファイルを削除します。
+
+    :param files: 削除するファイルのリスト
+    :type files: list[str]
+    :param db: データベースセッション (省略可能)
+    :type db: AsyncSession
+    :return: 削除結果の辞書
+    :rtype: dict
+    """
+    for file in files:
+        await files_cruds.delete_file_by_name(db, file)
+    return {"detail": "ファイルが削除されました"}

--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -92,31 +92,23 @@ async def get_file_by_id(
     return file
 
 
-# ファイルの削除
-@router.delete("/{file_id}", response_model=dict)
-async def delete_file(file_id: int, db: AsyncSession = db_dependency) -> dict:
-    file = await files_cruds.get_file_by_id(db, file_id)
-    if not file:
-        raise HTTPException(status_code=404, detail="ファイルが見つかりません")
-    await files_cruds.delete_file(db, file)
-    return {"detail": "ファイルが削除されました"}
-
-
-# ファイル名のリストによるファイルの削除
+# ファイル名のリストとユーザーIDによるファイルの削除
 @router.delete("/delete_files", response_model=dict)
-async def delete_files_by_name(
-    files: list[str], db: AsyncSession = db_dependency
+async def delete_files(
+    files: list[str], user_id: int, db: AsyncSession = db_dependency
 ) -> dict:
     """
-    ファイル名を指定してファイルを削除します。
+    ファイル名とユーザーIDによってファイルを削除します。
 
     :param files: 削除するファイルのリスト
     :type files: list[str]
+    :param user_id: ユーザーのID
+    :type user_id: int
     :param db: データベースセッション (省略可能)
-    :type db: AsyncSession
-    :return: 削除結果の辞書
+    :type db: AsyncSession, optional
+    :return: 削除の結果を示す辞書
     :rtype: dict
     """
-    for file in files:
-        await files_cruds.delete_file_by_name(db, file)
+    for file_name in files:
+        await files_cruds.delete_file_by_name_and_userid(db, file_name, user_id)
     return {"detail": "ファイルが削除されました"}

--- a/backend/tests/test_cruds_files.py
+++ b/backend/tests/test_cruds_files.py
@@ -30,6 +30,7 @@ async def test_create_file(session: AsyncSession, test_user_id: int) -> None:
         created_at=datetime.now(JST),
     )
     file = await files_cruds.create_file(session, file_create)
+
     assert file.id is not None
     assert file.file_name == "test_file.pdf"
     assert file.file_size == 12345
@@ -93,6 +94,24 @@ async def test_delete_file(session: AsyncSession, test_user_id: int) -> None:
     file = await files_cruds.create_file(session, file_create)
 
     await files_cruds.delete_file(session, file)
+    file_id = int(file.id)
+
+    retrieved_file = await files_cruds.get_file_by_id(session, file_id)
+    assert retrieved_file is None
+
+
+# ファイル名のリストによるファイル削除のテスト
+@pytest.mark.asyncio
+async def test_delete_file_by_name(session: AsyncSession, test_user_id: int) -> None:
+    file_create = files_schemas.FileCreate(
+        file_name="test_file.pdf",
+        file_size=12345,
+        user_id=test_user_id,
+        created_at=datetime.now(JST),
+    )
+    file = await files_cruds.create_file(session, file_create)
+
+    await files_cruds.delete_file_by_name(session, "test_file.pdf")
     file_id = int(file.id)
 
     retrieved_file = await files_cruds.get_file_by_id(session, file_id)

--- a/backend/tests/test_cruds_files.py
+++ b/backend/tests/test_cruds_files.py
@@ -81,26 +81,7 @@ async def test_get_file_by_id_not_found(session: AsyncSession) -> None:
     retrieved_file = await files_cruds.get_file_by_id(session, 9999)
     assert retrieved_file is None
 
-
-# ファイル削除のテスト
-@pytest.mark.asyncio
-async def test_delete_file(session: AsyncSession, test_user_id: int) -> None:
-    file_create = files_schemas.FileCreate(
-        file_name="test_file.pdf",
-        file_size=12345,
-        user_id=test_user_id,
-        created_at=datetime.now(JST),
-    )
-    file = await files_cruds.create_file(session, file_create)
-
-    await files_cruds.delete_file(session, file)
-    file_id = int(file.id)
-
-    retrieved_file = await files_cruds.get_file_by_id(session, file_id)
-    assert retrieved_file is None
-
-
-# ファイル名のリストによるファイル削除のテスト
+# ファイル名のリストとユーザーIDによるファイル削除のテスト
 @pytest.mark.asyncio
 async def test_delete_file_by_name(session: AsyncSession, test_user_id: int) -> None:
     file_create = files_schemas.FileCreate(
@@ -111,7 +92,9 @@ async def test_delete_file_by_name(session: AsyncSession, test_user_id: int) -> 
     )
     file = await files_cruds.create_file(session, file_create)
 
-    await files_cruds.delete_file_by_name(session, "test_file.pdf")
+    await files_cruds.delete_file_by_name_and_userid(
+        session, "test_file.pdf", test_user_id
+    )
     file_id = int(file.id)
 
     retrieved_file = await files_cruds.get_file_by_id(session, file_id)

--- a/backend/tests/test_routers_files.py
+++ b/backend/tests/test_routers_files.py
@@ -1,3 +1,4 @@
+from distutils import filelist
 from typing import AsyncGenerator
 
 import pytest
@@ -100,9 +101,9 @@ async def test_get_file_by_id(session: AsyncSession) -> None:
         assert data["file_name"] == "test_file.pdf"
 
 
-# ファイル削除のテスト
+# ファイル名のリストとユーザーIDによるファイルの削除のテスト
 @pytest.mark.asyncio
-async def test_delete_file(session: AsyncSession) -> None:
+async def test_delete_files(session: AsyncSession) -> None:
     user_id = await get_user_id(session)
 
     async with AsyncClient(
@@ -111,11 +112,17 @@ async def test_delete_file(session: AsyncSession) -> None:
     ) as client:
         file_content = b"test file content"
         files = [
-            ("files", ("test_file.pdf", file_content, "application/pdf")),
+            ("files", ("test_file1.pdf", file_content, "application/pdf")),
+            ("files", ("test_file2.pdf", file_content, "application/pdf")),
         ]
         await client.post(f"/files/upload?user_id={user_id}", files=files)
 
-        response = await client.delete("/files/1")
+        delete_files = ["test_file1.pdf", "test_file2.pdf"]
+        response = await client.request(
+            method="DELETE",
+            url=f"/files/delete_files?user_id={user_id}",
+            json=delete_files,
+        )
         print(response.text)  # デバッグ用出力
         assert response.status_code == 200
         data = response.json()

--- a/backend/tests/test_routers_files.py
+++ b/backend/tests/test_routers_files.py
@@ -126,7 +126,9 @@ async def test_delete_files(session: AsyncSession) -> None:
         print(response.text)  # デバッグ用出力
         assert response.status_code == 200
         data = response.json()
-        assert data["detail"] == "ファイルが削除されました"
+        assert data["success"] is True
+        assert len(data["success_files"]) == 2
+        assert len(data["failed_files"]) == 0
 
 
 # 存在しないファイルIDによるファイル取得のテスト
@@ -137,20 +139,6 @@ async def test_get_file_by_id_not_found(session: AsyncSession) -> None:
         base_url="http://test",
     ) as client:
         response = await client.get("/files/9999")
-        print(response.text)  # デバッグ用出力
-        assert response.status_code == 404
-        data = response.json()
-        assert data["detail"] == "ファイルが見つかりません"
-
-
-# 存在しないファイルIDによるファイル削除のテスト
-@pytest.mark.asyncio
-async def test_delete_file_not_found(session: AsyncSession) -> None:
-    async with AsyncClient(
-        transport=ASGITransport(app),  # type: ignore
-        base_url="http://test",
-    ) as client:
-        response = await client.delete("/files/9999")
         print(response.text)  # デバッグ用出力
         assert response.status_code == 404
         data = response.json()


### PR DESCRIPTION
## Issue No.

## 影響範囲とその理由
- 既存のfilesのDeleteエンドポイントを改修
- ユーザーIDとファイル名のリストを元にfilesテーブルからファイル情報を削除
- ファイル名のリストを元にGCSからファイルを削除

## チェックリスト
<!-- 変更を行った際にチェックした項目にチェックを入れてください。 -->
- [X] 単体テストを実施した
- [ ] 統合テストを実施した
- [ ] ドキュメントを更新した

## スクリーンショット
<!-- UIの変更がある場合は、Before / Afterのスクリーンショットや動作が分かるGIFなどを添付してください。 -->

## レビュアーに確認してほしいこと 
バックエンドのSwaggerUIからファイルが削除出来ることを確認
<img width="734" alt="image" src="https://github.com/AIIT-Oikawa-PBL-2024/AI-Notebook/assets/130154894/313b67a4-aeb4-4fe6-bef0-849577652885">


## 関連リンク
<!-- ソースコードに関連するファイルがあればリンクを共有 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 複数ファイルの一括削除機能を追加しました。ユーザーIDとファイル名リストに基づいて削除を行います。

- **バグ修正**
  - Google Cloud Storageからのファイル削除機能を強化し、削除結果を詳細に返すようにしました。

- **テスト**
  - 新しい一括削除機能に対応するテストケースを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->