### PR TITLE
feat: update README and Dockerfiles for cloud deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# AI-NoteBook-template
+# AI-Notebook
 
 フロントエンドは Streamlit、バックエンドは FastAPI を利用
 
 ```
-copilot-practice2
+AI-Notebook
 ├── .devcontainer
 │   └── backend
 |   |     └── devcontainer.json
@@ -28,8 +28,13 @@ copilot-practice2
 │   │    └── utils
 │   ├── tests
 │   ├── Dockerfile.backend
+│   ├── Dockerfile.cloud_backend
+│   ├── entrypoint.sh
 │   ├── poetry.lock
-│   └── pyproject.toml
+│   ├── pyproject.toml
+│   ├── pytest.ini
+│   └── README.md
+
 ├── frontend
 │   ├── .vscode
 │   │    └── settings.json
@@ -38,8 +43,12 @@ copilot-practice2
 │   ├── app.py
 │   ├── tests
 │   ├── Dockerfile.frontend
+│   ├── Dockerfile.cloud_frontend
+│   ├── entrypoint.sh
 │   ├── poetry.lock
-│   └── pyproject.toml
+│   ├── pyproject.toml
+│   ├── pytest.ini
+│   └── README.md
 ├── docker-compose.yml
 ├── .env.sample
 ├── .coderabbit.yaml

--- a/backend/Dockerfile.cloud_backend
+++ b/backend/Dockerfile.cloud_backend
@@ -12,14 +12,14 @@ WORKDIR /backend
 RUN pip install --no-cache-dir poetry==1.8.3
 
 # 依存ファイルをコピーして依存関係をインストール
-COPY backend/pyproject.toml backend/poetry.lock /backend/
+COPY pyproject.toml poetry.lock ./
 
-# デプロイに必要
-COPY backend/app /backend/app
-COPY backend/entrypoint.sh /backend/entrypoint.sh
-
-# poetryの設定
+# poetryの設定と依存関係のインストール
 RUN poetry config virtualenvs.in-project true && poetry install --no-root --no-dev
+
+# デプロイに必要なファイルをコピー
+COPY app ./app
+COPY entrypoint.sh ./entrypoint.sh
 
 # gcloud SDKのインストール(最新google-cloud-sdkを使うため、version指定しない)
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \

--- a/backend/README.md
+++ b/backend/README.md
@@ -35,6 +35,7 @@
         `--role="roles/run.admin"`
 
 ### Dockerイメージの作成
+- `cd backend`
 - `docker build -t gcr.io/<PJNAME>/<APPNAME>:latest --platform linux/amd64 \`
     `-f  backend/Dockerfile.cloud_backend .`
 

--- a/frontend/Dockerfile.cloud_frontend
+++ b/frontend/Dockerfile.cloud_frontend
@@ -12,16 +12,15 @@ WORKDIR /frontend
 RUN pip install --no-cache-dir poetry==1.8.3
 
 # 依存ファイルをコピーして依存関係をインストール
-COPY frontend/pyproject.toml frontend/poetry.lock /frontend/
-
-
-# デプロイに必要
-COPY frontend/app /frontend/app
-COPY frontend/.streamlit /frontend/.streamlit
-COPY frontend/entrypoint.sh /frontend/entrypoint.sh
+COPY pyproject.toml poetry.lock ./
 
 # poetryの設定と依存関係のインストール
 RUN poetry config virtualenvs.in-project true && poetry install --no-root --no-dev
 
-# DBのマイグレーションを実行、fastapiの起動
+# デプロイに必要なファイルをコピー
+COPY app ./app
+COPY .streamlit ./.streamlit
+COPY entrypoint.sh ./entrypoint.sh
+
+# エントリーポイントの設定
 ENTRYPOINT ["bash", "entrypoint.sh"]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -32,6 +32,7 @@
         `--role="roles/run.admin"`
 
 ### Dockerイメージの作成
+- `cd frontend`
 - `docker build -t gcr.io/<PJNAME>/<APPNAME>:latest --platform linux/amd64 \`
     `-f frontend/Dockerfile.cloud_frontend .`
 


### PR DESCRIPTION
## Issue No.
#101 

## 影響範囲とその理由
<!-- この変更により起こり得る影響範囲とその理由を書いてください。 -->
GCP側でGitHubリポジトリと連携させたが、パスが見つからずエラーになっています。
ルートからではなく、Dockerfileがある階層のディレクトリから自動ビルドしている可能性があるので、
Dockerfileのコピーパスの設定を変更しました。

https://console.cloud.google.com/cloud-build/builds;region=global/842a2744-b9d3-4a26-8f74-9cd3cfcabc41?hl=ja&project=oikawapbl2024

https://github.com/AIIT-Oikawa-PBL-2024/AI-Notebook/runs/27119512957

## チェックリスト
<!-- 変更を行った際にチェックした項目にチェックを入れてください。 -->
- [ ] 単体テストを実施した
- [ ] 統合テストを実施した
- [x] ドキュメントを更新した

## スクリーンショット
<!-- UIの変更がある場合は、Before / Afterのスクリーンショットや動作が分かるGIFなどを添付してください。 -->

## レビュアーに確認してほしいこと 
<!-- テストや事象の再現が必要な場合、レビュアーが再現できる実施手順を必ず明記してください！ -->
<!-- レビュワーに特に注目してほしいポイントや、不安な部分があれば明記してください。 -->
mainにマージしてみないと通るかわからないので、問題なければ、承認いただけると助かります。

## 関連リンク
<!-- ソースコードに関連するファイルがあればリンクを共有 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - プロジェクト名を `AI-NoteBook-template` から `AI-Notebook` に変更
  - 新しい Dockerfile とエントリーポイントスクリプトを追加（クラウド用バックエンドとフロントエンド）

- **ドキュメント**
  - `backend/README.md` と `frontend/README.md` に Dockerイメージ作成手順を更新

- **リファクタ**
  - Dockerfile のファイルコピー手順とエントリーポイントスクリプトの実行方法を改善

<!-- end of auto-generated comment: release notes by coderabbit.ai -->