### PR TITLE
ファイル選択ページ修正・追加

### DIFF
--- a/frontend/app/pages/select_files.py
+++ b/frontend/app/pages/select_files.py
@@ -28,6 +28,10 @@ BACKEND_HOST = os.getenv("BACKEND_HOST")
 BACKEND_DEV_API_URL = f"{BACKEND_HOST}/files/"
 
 # セッション状態の初期化
+if "title_name" not in st.session_state:
+    st.session_state.title_name = ""
+if "exercise_name" not in st.session_state:
+    st.session_state.exercise_name = ""
 if "note_name" not in st.session_state:
     st.session_state.note_name = ""
 if "df" not in st.session_state:
@@ -155,7 +159,7 @@ async def show_select_files_page() -> None:
     st.header("AIノートを作成", divider="blue")
 
     # ボタンの配置
-    col1, col2, _, _ = st.columns([1, 1, 1, 1])
+    col1, col2, _, _ = st.columns([1.5, 1, 1, 1])
     with col1:
         get_files_button = st.button("ファイル一覧を取得", use_container_width=True)
     with col2:
@@ -182,40 +186,54 @@ async def show_select_files_page() -> None:
             st.text(selected_files)
             st.divider()
 
-            # ノート名を入力
-            st.write(":blue-background[ノート名]")
+            # タイトルを入力
+            st.write(":blue-background[タイトル]")
             st.text_input(
-                "AIで作成するノートのタイトルを100文字以内で入力してEnterキーを押して下さい",
-                key="note_input",
-                value=st.session_state.note_name,
-                on_change=update_note_name,
+                "AIで作成するノートや練習問題のタイトルを100文字以内で入力してEnterキーを押して下さい",
+                key="title_input",
+                value=st.session_state.title_name,
+                on_change=update_title_name,
                 max_chars=100,
             )
 
-            # 現在のノートタイトルを表示
-            st.write(f"Note Title:  {st.session_state.note_name}")
+            # 現在のタイトルを表示
+            st.write(f"Title:  {st.session_state.title_name}")
 
             # AIノート作成ボタン
-            if selected_files and st.session_state.note_name:
+            if selected_files and st.session_state.title_name:
                 st.divider()
                 if st.button(
                     "AIノートを作成", use_container_width=True, type="primary"
                 ):
+                    st.session_state.note_name = st.session_state.title_name
                     st.session_state.selected_files = (
                         selected_files  # 選択されたファイルをセッション状態に保存
                     )
                     st.session_state.page = "pages/study_ai_note.py"  # ページを指定
                     st.switch_page("pages/study_ai_note.py")  # ページに遷移
 
+            # AI練習問題作成ボタン
+            if selected_files and st.session_state.title_name:
+                st.divider()
+                if st.button(
+                    "AI練習問題を作成", use_container_width=True, type="primary"
+                ):
+                    st.session_state.exercise_name = st.session_state.title_name
+                    st.session_state.selected_files = (
+                        selected_files  # 選択されたファイルをセッション状態に保存
+                    )
+                    st.session_state.page = "pages/study_ai_exercise.py"  # ページを指定
+                    st.switch_page("pages/study_ai_exercise.py")  # ページに遷移
 
-# ノート名を更新する関数
-def update_note_name() -> None:
+
+# タイトル名を更新する関数
+def update_title_name() -> None:
     """
-    ノート名をセッション状態に反映する。
+    タイトル名をセッション状態に反映する。
 
     :return: None
     """
-    st.session_state.note_name = st.session_state.note_input
+    st.session_state.title_name = st.session_state.title_input
 
 
 # ファイル選択ページの処理を実行

--- a/frontend/tests/test_select_files.py
+++ b/frontend/tests/test_select_files.py
@@ -6,7 +6,7 @@ from app.pages.select_files import (
     time_format,
     update,
     get_selected_files,
-    update_note_name,
+    update_title_name,
     show_select_files_page,
 )
 import streamlit as st
@@ -293,23 +293,23 @@ def test_get_selected_files_empty_df(mocker: MagicMock) -> None:
         assert selected_files == []
 
 
-# update_note_name 関数のテスト
-def test_update_note_name(mocker: MagicMock) -> None:
+# update_title_name 関数のテスト
+def test_update_title_name(mocker: MagicMock) -> None:
     """
-    update_note_name関数のテストを行います。
+    update_title_name関数のテストを行います。
 
     :param mocker: MagicMockオブジェクト
     """
     # モックされたセッション状態を設定
-    mock_session_state = {"note_input": "New Note Title"}
+    mock_session_state = {"title_input": "New Note Title"}
 
     # session_state を辞書としてモック
     with patch.dict("streamlit.session_state", mock_session_state):
         # 関数を呼び出して結果を検証
-        update_note_name()
+        update_title_name()
 
-        # note_nameが正しく更新されているかを検証
-        assert st.session_state.note_name == "New Note Title"
+        # title_nameが正しく更新されているかを検証
+        assert st.session_state.title_name == "New Note Title"
 
 
 # show_select_files_page 関数のテスト
@@ -324,6 +324,7 @@ async def test_show_select_files_page() -> None:
         - セッション状態の更新
         - テキスト入力フィールドの確認
         - "AIノートを作成"ボタンの表示確認
+        - "AI練習問題を作成"ボタンの表示確認
         - テキスト入力フィールドに値を入力
         - ページ遷移の確認
     """
@@ -374,7 +375,7 @@ async def test_show_select_files_page() -> None:
     if len(at.text_input) > 0:
         print(f"Text input label: {at.text_input[0].label}")
         assert (
-            "AIで作成するノートのタイトルを100文字以内で入力してEnterキーを押して下さい"
+            "AIで作成するノートや練習問題のタイトルを100文字以内で入力してEnterキーを押して下さい"
             in at.text_input[0].label
         )
 
@@ -385,9 +386,16 @@ async def test_show_select_files_page() -> None:
         "AIノートを作成" not in button_labels
     ), "AIノートを作成'ボタンが表示されていますが、テキストが入力されていません"
 
+    # "AI練習問題を作成"ボタンが表示されないことを確認（テキストが入力されていない場合）
+    button_labels = [button.label for button in at.button]
+    print(f"Button labels: {button_labels}")
+    assert (
+        "AI練習問題を作成" not in button_labels
+    ), "AI練習問題を作成'ボタンが表示されていますが、テキストが入力されていません"
+
     # テキスト入力フィールドに値を入力
-    at.session_state["note_input"] = "ノートのタイトル"
-    at.session_state["note_name"] = "ノートのタイトル"
+    at.session_state["title_input"] = "タイトル"
+    at.session_state["title_name"] = "タイトル"
     at.run()
 
     # 再度状態を確認
@@ -399,8 +407,8 @@ async def test_show_select_files_page() -> None:
 
     # テキスト入力フィールドの値を確認
     assert (
-        at.session_state["note_input"] == "ノートのタイトル"
-    ), f"Expected 'ノートのタイトル', but got {at.session_state['note_input']}"
+        at.session_state["title_input"] == "タイトル"
+    ), f"Expected 'タイトル', but got {at.session_state['title_input']}"
 
     # "AIノートを作成"ボタンが表示されることを確認（テキストが入力された場合）
     button_labels = [button.label for button in at.button]
@@ -408,6 +416,13 @@ async def test_show_select_files_page() -> None:
     assert (
         "AIノートを作成" in button_labels
     ), "'AIノートを作成'ボタンが表示されていません"
+
+    # "AI練習問題を作成"ボタンが表示されることを確認（テキストが入力された場合）
+    button_labels = [button.label for button in at.button]
+    print(f"Button labels: {button_labels}")
+    assert (
+        "AI練習問題を作成" in button_labels
+    ), "'AI練習問題を作成'ボタンが表示されていません"
 
     # "AIノートを作成"ボタンをクリック
     create_note_button = next(
@@ -418,6 +433,8 @@ async def test_show_select_files_page() -> None:
 
     # ページが遷移したことを確認
     assert at.session_state["page"] == "pages/study_ai_note.py"
+
+    # Todo : pages/study_ai_exercise.pyを作成したらAI練習問題を作成ボタンのテストを追加する
 
 
 # リセットボタンのテスト
@@ -463,5 +480,5 @@ async def test_reset_button() -> None:
     at.run()
 
     # 入力がリセットされたことを確認
-    assert at.session_state["note_name"] == ""
+    assert at.session_state["title_name"] == ""
     assert at.session_state["selected_files"] == []


### PR DESCRIPTION
## Issue No.
#123 
#124 

## 影響範囲とその理由
- ファイル一覧取得ボタンの幅を調整
- ノート名をタイトルに表示変更（タイトルをノート名と練習問題名の両方で利用するため）

## チェックリスト
<!-- 変更を行った際にチェックした項目にチェックを入れてください。 -->
- [X] 単体テストを実施した
- [ ] 統合テストを実施した
- [ ] ドキュメントを更新した

## スクリーンショット
- 画像黒枠部分を修正・追加
<img width="618" alt="image" src="https://github.com/AIIT-Oikawa-PBL-2024/AI-Notebook/assets/130154894/4b9fa3bb-4176-4d82-b7d7-6433bbfeb241">

## レビュアーに確認してほしいこと 
- ファイル一覧取得ボタンが改行されていないこと
- フロントエンドのpytestが通ること
- AIノートを作成ボタンが問題なく動作すること

## 関連リンク
<!-- ソースコードに関連するファイルがあればリンクを共有 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - タイトルに基づいてAI練習問題を作成する機能を追加しました。
  
- **変更点**
  - "ノート" から "タイトル" への用語変更を行いました。
  - UI要素とセッション状態管理の更新を行いました。

- **テスト**
  - テストケースを用語変更に合わせて更新し、"AI練習問題を作成" ボタンのラベルチェックを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->