### PR TITLE
(若林frontend) add reStructuredText style docstring

### DIFF
--- a/frontend/app/pages/select_files.py
+++ b/frontend/app/pages/select_files.py
@@ -157,6 +157,7 @@ async def delete_selected_files(files: list[str]) -> None:
     :param files: 削除するファイル名のリスト
     :type files: list[str]
     :return: None
+    :rtype: None
     """
     try:
         user_id = 1  # ユーザーIDを固定値（1）で設定

--- a/frontend/tests/test_select_files.py
+++ b/frontend/tests/test_select_files.py
@@ -579,7 +579,15 @@ async def test_reset_button() -> None:
 
 # delete_selected_files 関数のテスト
 @pytest.mark.asyncio
-async def test_delete_selected_files(mocker):
+async def test_delete_selected_files(mocker: MagicMock) -> None:
+    """
+    delete_selected_files関数の正常系テスト。
+
+    :param mocker: pytestのモッカーオブジェクト
+    :type mocker: MagicMock
+
+    :raises AssertionError: テストの検証に失敗した場合
+    """
     # モックセッション状態の設定
     mock_session_state = {
         "df": pd.DataFrame(
@@ -627,7 +635,15 @@ async def test_delete_selected_files(mocker):
 
 
 @pytest.mark.asyncio
-async def test_delete_selected_files_http_status_error(mocker):
+async def test_delete_selected_files_http_status_error(mocker: MagicMock) -> None:
+    """
+    delete_selected_files関数のHTTPステータスエラー時のテスト。
+
+    :param mocker: pytestのモッカーオブジェクト
+    :type mocker: MagicMock
+
+    :raises AssertionError: テストの検証に失敗した場合
+    """
     # モックセッション状態の設定
     mock_session_state = {
         "df": pd.DataFrame(


### PR DESCRIPTION
## Issue No.
<!-- 対応しているissue番号を貼る。 -->
https://github.com/AIIT-Oikawa-PBL-2024/AI-Notebook/issues/108
## 影響範囲とその理由
<!-- この変更により起こり得る影響範囲とその理由を書いてください。 -->
なし
## チェックリスト
<!-- 変更を行った際にチェックした項目にチェックを入れてください。 -->
- [x] 単体テストを実施した
- [ ] 統合テストを実施した
- [ ] ドキュメントを更新した

## スクリーンショット
<!-- UIの変更がある場合は、Before / Afterのスクリーンショットや動作が分かるGIFなどを添付してください。 -->

![スクリーンショット 2024-07-15 0 04 33](https://github.com/user-attachments/assets/de5d53a0-bc9a-425c-a014-f396ed304e9e)

## レビュアーに確認してほしいこと 
<!-- テストや事象の再現が必要な場合、レビュアーが再現できる実施手順を必ず明記してください！ -->
<!-- レビュワーに特に注目してほしいポイントや、不安な部分があれば明記してください。 -->

以下2ファイルの担当箇所にdocstringを追記しましたのでご確認よろしくお願いします。
- select_files.py
- test_select_files.py（テストコードに返り血の型[None]が抜けていたので、そちらも追記しています。pytestを念のため再度実行し通っております。）

## 関連リンク
<!-- ソースコードに関連するファイルがあればリンクを共有 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
  - `delete_selected_files` 関数に `:rtype: None` を追加して、戻り値の型を明示。
  - テスト関数にドキュメントストリングを追加して、目的を明確化。

- **テスト**
  - テスト関数の `mocker` パラメータに型注釈 `MagicMock` を追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->