### PR TITLE
ファイル選択ページとAIノート/AI練習問題の動作を修正

### DIFF
--- a/frontend/app/pages/select_files.py
+++ b/frontend/app/pages/select_files.py
@@ -40,8 +40,10 @@ if "df" not in st.session_state:
     st.session_state.df = None
 if "df_updated" not in st.session_state:
     st.session_state.df_updated = False
-if "selected_files" not in st.session_state:
-    st.session_state.selected_files = []
+if "selected_files_note" not in st.session_state:
+    st.session_state.selected_files_note = []
+if "selected_files_exercise" not in st.session_state:
+    st.session_state.selected_files_exercise = []
 
 
 # 時刻フォーマットを変換する関数
@@ -285,7 +287,7 @@ async def show_select_files_page() -> None:
                     "AIノートを作成", use_container_width=True, type="primary"
                 ):
                     st.session_state.note_name = st.session_state.title_name
-                    st.session_state.selected_files = (
+                    st.session_state.selected_files_note = (
                         selected_files  # 選択されたファイルをセッション状態に保存
                     )
                     st.session_state.page = "pages/study_ai_note.py"  # ページを指定
@@ -298,7 +300,7 @@ async def show_select_files_page() -> None:
                     "AI練習問題を作成", use_container_width=True, type="primary"
                 ):
                     st.session_state.exercise_name = st.session_state.title_name
-                    st.session_state.selected_files = (
+                    st.session_state.selected_files_exercise = (
                         selected_files  # 選択されたァイルをセッション状態に保存
                     )
                     st.session_state.page = "pages/study_ai_exercise.py"  # ページを指定

--- a/frontend/app/pages/study_ai_exercise.py
+++ b/frontend/app/pages/study_ai_exercise.py
@@ -39,12 +39,15 @@ def show_output_page() -> None:
     """
     st.header("AI練習問題", divider="blue")
 
-    if "selected_files" in st.session_state and st.session_state.selected_files:
+    if (
+        "selected_files_exercise" in st.session_state
+        and st.session_state.selected_files_exercise
+    ):
         exercise_name = st.session_state["exercise_name"]
         st.subheader(f"Exercise Title: {exercise_name}")
         st.write("選択されたファイル:")
-        st.text(st.session_state.selected_files)
-        selected_files = st.session_state.get("selected_files", [])
+        st.text(st.session_state.selected_files_exercise)
+        selected_files = st.session_state.get("selected_files_exercise", [])
 
         if selected_files:
             with st.spinner("処理中です。お待ちください..."):

--- a/frontend/app/pages/study_ai_note.py
+++ b/frontend/app/pages/study_ai_note.py
@@ -39,12 +39,15 @@ def show_output_page() -> None:
     """
     st.header("AIノート", divider="blue")
 
-    if "selected_files" in st.session_state and st.session_state.selected_files:
+    if (
+        "selected_files_note" in st.session_state
+        and st.session_state.selected_files_note
+    ):
         note_name = st.session_state["note_name"]
         st.subheader(f"Note Title: {note_name}")
         st.write("選択されたファイル:")
-        st.text(st.session_state.selected_files)
-        selected_files = st.session_state.get("selected_files", [])
+        st.text(st.session_state.selected_files_note)
+        selected_files = st.session_state.get("selected_files_note", [])
 
         if selected_files:
             with st.spinner("処理中です。お待ちください..."):

--- a/frontend/tests/test_select_files.py
+++ b/frontend/tests/test_select_files.py
@@ -574,7 +574,8 @@ async def test_reset_button() -> None:
 
     # 入力がリセットされたことを確認
     assert at.session_state["title_name"] == ""
-    assert at.session_state["selected_files"] == []
+    assert at.session_state["selected_files_note"] == []
+    assert at.session_state["selected_files_exercise"] == []
 
 
 # delete_selected_files 関数のテスト

--- a/frontend/tests/test_study_ai_exercise.py
+++ b/frontend/tests/test_study_ai_exercise.py
@@ -13,7 +13,7 @@ BACKEND_DEV_API_URL = f"{BACKEND_HOST}/exercises/request_stream"
 # テスト用のフィクスチャ
 @pytest.fixture
 def mock_session_state() -> Generator:
-    st.session_state.selected_files = ["file1.pdf", "file2.pdf"]
+    st.session_state.selected_files_exercise = ["file1.pdf", "file2.pdf"]
     st.session_state.exercise_name = "Test Xxercise"
     yield
     st.session_state.clear()
@@ -26,11 +26,11 @@ def test_create_study_ai_exercise_success(
 ) -> None:
     mock_create_pdf_to_markdown_summary.return_value = "Mocked AI Exercise"
     result = create_study_ai_exercise(
-        st.session_state.selected_files, BACKEND_DEV_API_URL
+        st.session_state.selected_files_exercise, BACKEND_DEV_API_URL
     )
     assert result == "Mocked AI Exercise"
     mock_create_pdf_to_markdown_summary.assert_called_once_with(
-        st.session_state.selected_files, BACKEND_DEV_API_URL
+        st.session_state.selected_files_exercise, BACKEND_DEV_API_URL
     )
 
 
@@ -46,7 +46,7 @@ def test_create_study_ai_exercise_exception(
 ) -> None:
     mock_create_pdf_to_markdown_summary.side_effect = Exception("Test Exception")
     result = create_study_ai_exercise(
-        st.session_state.selected_files, BACKEND_DEV_API_URL
+        st.session_state.selected_files_exercise, BACKEND_DEV_API_URL
     )
     assert result is None
     mock_logging.error.assert_called_once_with(
@@ -84,10 +84,10 @@ def test_show_output_page_success(
         f"Exercise Title: {st.session_state.exercise_name}"
     )
     mock_write.assert_called_once_with("選択されたファイル:")
-    mock_text.assert_called_once_with(st.session_state.selected_files)
+    mock_text.assert_called_once_with(st.session_state.selected_files_exercise)
     mock_spinner.assert_called_once_with("処理中です。お待ちください...")
     mock_create_study_ai_exercise.assert_called_once_with(
-        st.session_state.selected_files, BACKEND_DEV_API_URL
+        st.session_state.selected_files_exercise, BACKEND_DEV_API_URL
     )
     mock_success.assert_called_once_with("処理が完了しました")
     mock_error.assert_not_called()

--- a/frontend/tests/test_study_ai_note.py
+++ b/frontend/tests/test_study_ai_note.py
@@ -9,7 +9,7 @@ from typing import Generator
 # テスト用のフィクスチャ
 @pytest.fixture
 def mock_session_state() -> Generator:
-    st.session_state.selected_files = ["file1.pdf", "file2.pdf"]
+    st.session_state.selected_files_note = ["file1.pdf", "file2.pdf"]
     st.session_state.note_name = "Test Note"
     yield
     st.session_state.clear()
@@ -26,10 +26,12 @@ def test_create_study_ai_note_success(
     mock_create_pdf_to_markdown_summary: MagicMock, mock_session_state: Generator
 ) -> None:
     mock_create_pdf_to_markdown_summary.return_value = "Mocked AI Note"
-    result = create_study_ai_note(st.session_state.selected_files, BACKEND_DEV_API_URL)
+    result = create_study_ai_note(
+        st.session_state.selected_files_note, BACKEND_DEV_API_URL
+    )
     assert result == "Mocked AI Note"
     mock_create_pdf_to_markdown_summary.assert_called_once_with(
-        st.session_state.selected_files, BACKEND_DEV_API_URL
+        st.session_state.selected_files_note, BACKEND_DEV_API_URL
     )
 
 
@@ -44,7 +46,9 @@ def test_create_study_ai_note_exception(
     mock_session_state: Generator,
 ) -> None:
     mock_create_pdf_to_markdown_summary.side_effect = Exception("Test Exception")
-    result = create_study_ai_note(st.session_state.selected_files, BACKEND_DEV_API_URL)
+    result = create_study_ai_note(
+        st.session_state.selected_files_note, BACKEND_DEV_API_URL
+    )
     assert result is None
     mock_logging.error.assert_called_once_with(
         "AIノートの生成中にエラーが発生しました: Test Exception"
@@ -79,10 +83,10 @@ def test_show_output_page_success(
     mock_header.assert_called_once_with("AIノート", divider="blue")
     mock_subheader.assert_called_once_with(f"Note Title: {st.session_state.note_name}")
     mock_write.assert_called_once_with("選択されたファイル:")
-    mock_text.assert_called_once_with(st.session_state.selected_files)
+    mock_text.assert_called_once_with(st.session_state.selected_files_note)
     mock_spinner.assert_called_once_with("処理中です。お待ちください...")
     mock_create_study_ai_note.assert_called_once_with(
-        st.session_state.selected_files, BACKEND_DEV_API_URL
+        st.session_state.selected_files_note, BACKEND_DEV_API_URL
     )
     mock_success.assert_called_once_with("処理が完了しました")
     mock_error.assert_not_called()


### PR DESCRIPTION
## Issue No.


## 影響範囲とその理由
先日のフロントのエラーを確認しているときに気になる動作があったので修正
ファイル選択ページでファイルを選択
→AIノート作成ボタンを押下
→AIノートが作成される
→AI練習問題ページに手動で遷移
→AI練習問題が作成されてしまう（ここを作成されないように修正）

もしくは
ファイル選択ページでファイルを選択
→AI練習問題作成ボタンを押下
→AI練習問題が作成される
→AIノートページに手動で遷移
→AIノートが作成されてしまう（ここを作成されないように修正）

## チェックリスト
<!-- 変更を行った際にチェックした項目にチェックを入れてください。 -->
- [X] 単体テストを実施した
- [ ] 統合テストを実施した
- [ ] ドキュメントを更新した

## スクリーンショット

## レビュアーに確認してほしいこと 
- フロントのpytestが通ること
- 問題の動作を行ってAI練習問題が勝手に作成されないこと

## 関連リンク
<!-- ソースコードに関連するファイルがあればリンクを共有 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **機能改善**
  - セッションステート変数を `selected_files` から `selected_files_note` と `selected_files_exercise` に分割し、それぞれAIノート作成とエクササイズ作成に対応。
- **バグ修正**
  - ノートとエクササイズの選択ファイルが区別されるようにセッションステートのキーを更新。
- **テスト**
  - 新しいセッションステート変数 `selected_files_note` と `selected_files_exercise` を検証するためのテストケースを追加し、既存テストを更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->