### PR TITLE
ファイルセレクトページのリセットボタン修正

### DIFF
--- a/frontend/.vscode/extensions.json
+++ b/frontend/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "charliermarsh.ruff",
+        "ms-python.mypy-type-checker"
+    ]
+}

--- a/frontend/app/pages/select_files.py
+++ b/frontend/app/pages/select_files.py
@@ -239,8 +239,11 @@ async def show_select_files_page() -> None:
     if get_files_button:
         await show_files_list_df()
 
+    # リセットボタンが押された場合の処理
     if reset_button:
-        st.session_state.clear()
+        st.session_state.df = None
+        st.session_state.df_updated = False
+        st.session_state.title_name = ""
         st.rerun()
     # ファイル削除ボタンが押された場合の処理を追記しております（若林）
     if delete_button:


### PR DESCRIPTION
## Issue No.
<!-- 対応しているissue番号を貼る。 -->

## 影響範囲とその理由
<!-- この変更により起こり得る影響範囲とその理由を書いてください。 -->
リセットボタンを押すと、すべてのセッションが消えてしまっていたので、
ファイルセレクトページのデータフレーム、タイトルのみを初期化するように変更しました。

## チェックリスト
<!-- 変更を行った際にチェックした項目にチェックを入れてください。 -->
- [x] 単体テストを実施した
- [ ] 統合テストを実施した
- [ ] ドキュメントを更新した

## スクリーンショット
<!-- UIの変更がある場合は、Before / Afterのスクリーンショットや動作が分かるGIFなどを添付してください。 -->
https://drive.google.com/file/d/14UHXr14N5V9V9zitZB1cYy0Am-gkCGS3/view?usp=sharing

## レビュアーに確認してほしいこと 
<!-- テストや事象の再現が必要な場合、レビュアーが再現できる実施手順を必ず明記してください！ -->
<!-- レビュワーに特に注目してほしいポイントや、不安な部分があれば明記してください。 -->
上記の動画のようにリセットボタンを押しても、AIノートや練習問題の出力が消えないことを確認していただきたいです。

## 関連リンク
<!-- ソースコードに関連するファイルがあればリンクを共有 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- フロントエンド開発環境に推奨されるVisual Studio Code拡張機能を指定する新しい設定ファイルを追加しました。
	- リセットボタンの機能が改善され、セッション状態の特定の変数のみがリセットされるようになりました。

- **バグ修正**
	- リセットボタンを押した際のセッション状態のクリア動作が改善され、他のデータが影響を受けないようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->