### PR TITLE
アップロード用の署名付きURL機能の実装（バックエンド）

### DIFF
--- a/backend/tests/test_operate_cloud_strage.py
+++ b/backend/tests/test_operate_cloud_strage.py
@@ -8,6 +8,7 @@ from app.utils.operate_cloud_storage import (
     post_files,
     upload_files,
     delete_files_from_gcs,
+    generate_upload_signed_url_v4,
 )
 from app.main import app
 from unittest.mock import patch, MagicMock
@@ -238,3 +239,20 @@ async def test_delete_files_from_gcs() -> None:
         result = await delete_files_from_gcs(deletefiles)
         assert result["success"] == False
         assert "Delete failed" in result["failed_files"]
+
+
+@pytest.mark.asyncio
+async def test_generate_upload_signed_url_v4() -> None:
+    # 署名付きURLを作成するファイル名のリスト
+    testfiles: list[str] = [
+        "5_アジャイルⅡ.pdf",
+        "AI-powered Code Review with LLM.pdf",
+    ]
+
+    # 署名付きURLを作成する
+    result = await generate_upload_signed_url_v4(testfiles)
+
+    # 結果の検証
+    assert result["5_アジャイルⅡ.pdf"] is not None
+    assert result["AI-powered Code Review with LLM.pdf"] is not None
+    assert len(result) == 2

--- a/backend/tests/test_routers_files.py
+++ b/backend/tests/test_routers_files.py
@@ -192,3 +192,24 @@ async def test_upload_file_with_dakuten(session: AsyncSession) -> None:
         assert uploaded_filename == nfc_filename
         assert uploaded_filename != nfd_filename
         assert unicodedata.is_normalized("NFC", uploaded_filename)
+
+
+# 署名付きURL取得のテスト
+@pytest.mark.asyncio
+async def test_generate_upload_signed_url(session: AsyncSession) -> None:
+    user_id = await get_user_id(session)
+
+    async with AsyncClient(
+        transport=ASGITransport(app),  # type: ignore
+        base_url="http://test",
+    ) as client:
+        testfiles = ["test_file1.pdf", "test_file2.pdf"]
+        response = await client.post(
+            f"/files/generate_upload_signed_url/",
+            json=testfiles,
+        )
+        print(response.text)  # デバッグ用出力
+        assert response.status_code == 200
+        data = response.json()
+        assert data["test_file1.pdf"] is not None
+        assert data["test_file2.pdf"] is not None

--- a/backend/tests/test_routers_files.py
+++ b/backend/tests/test_routers_files.py
@@ -213,3 +213,32 @@ async def test_generate_upload_signed_url(session: AsyncSession) -> None:
         data = response.json()
         assert data["test_file1.pdf"] is not None
         assert data["test_file2.pdf"] is not None
+
+
+# ファイル登録のテスト
+@pytest.mark.asyncio
+async def test_register_files(session: AsyncSession) -> None:
+    """
+    ファイル登録のエンドポイントをテストする関数
+
+    :param session: テスト用のデータベースセッション
+    :type session: AsyncSession
+    :return: None
+    :raises AssertionError: テストが失敗した場合
+    """
+    user_id = await get_user_id(session)
+
+    file_content = b"test file content"
+    files = [
+        ("files", ("test_file.pdf", file_content, "application/pdf")),
+    ]
+    async with AsyncClient(
+        transport=ASGITransport(app),  # type: ignore
+        base_url="http://test",
+    ) as client:
+        response = await client.post(
+            f"/files/register_files?user_id={user_id}", files=files
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data is True


### PR DESCRIPTION
## Issue No.
#165 

## 影響範囲とその理由
署名付きURLを取得するエンドポイントを追加
署名付きURLからファイルをアップロードした後に、ファイル情報をDBにだけ登録するエンドポイントを追加

## チェックリスト
- [X] 単体テストを実施した
- [ ] 統合テストを実施した
- [ ] ドキュメントを更新した

## スクリーンショット
<!-- UIの変更がある場合は、Before / Afterのスクリーンショットや動作が分かるGIFなどを添付してください。 -->

## レビュアーに確認してほしいこと 
バックエンドのpytestが通ること
Swagger UIからアップロード用の署名付きURLを取得出来ること
Swagger UIからファイル情報の登録が出来ること

## 関連リンク
アップロード用の署名付きURLは事前にアップロードするファイル名を指定する必要があり、
ファイル名ごとの取得が必要なようです、以下サンプルコード
https://cloud.google.com/storage/docs/samples/storage-generate-upload-signed-url-v4?hl=ja

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- Google Cloud Storageへのファイルアップロード用の署名付きURLを生成する新しいエンドポイントを追加しました。
	- アップロードされたファイルをデータベースに登録するための新しいエンドポイントを追加しました。
- **バグ修正**
	- 署名付きURL生成機能に関するテストを追加し、正常に動作することを確認しました。
	- ファイル登録機能に関するテストを追加し、正常に動作することを確認しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->