### PR TITLE
サインイン前はNavBarが表示されないように修正

### DIFF
--- a/frontend-nextjs/__tests__/components/layouts/NavBar.test.tsx
+++ b/frontend-nextjs/__tests__/components/layouts/NavBar.test.tsx
@@ -20,7 +20,12 @@ describe("NavBar", () => {
 	});
 
 	it("NavBarコンポーネントがレンダリングされること", () => {
-		(useAuth as Mock).mockReturnValue({ user: null });
+		(useAuth as Mock).mockReturnValue({
+			user: {
+				displayName: "テストユーザー",
+				email: "test@example.com",
+			},
+		});
 		(useSignOut as Mock).mockReturnValue({
 			signOutUser: vi.fn(),
 			error: null,

--- a/frontend-nextjs/components/layouts/NavBar.tsx
+++ b/frontend-nextjs/components/layouts/NavBar.tsx
@@ -22,6 +22,10 @@ export default function NavBar() {
 	const { user } = useAuth();
 	const { signOutUser, error, isLoading } = useSignOut();
 
+	if (!user) {
+		return null; // ユーザーが存在しない場合は何も表示しない
+	}
+
 	return (
 		<Card className="h-[calc(100vh-2rem)] w-full max-w-[20rem] p-4 shadow-xl shadow-blue-gray-900/5">
 			<div className="mb-2 p-4">


### PR DESCRIPTION
## Issue No.

## 影響範囲とその理由
トップページにアクセスした際に一瞬NavBarが表示された後にサインインぺージが表示されるようになっていたため、
サインイン前はNavBarが表示されないように修正しました。

## チェックリスト
<!-- 変更を行った際にチェックした項目にチェックを入れてください。 -->
- [X] 単体テストを実施した
- [ ] 統合テストを実施した
- [ ] ドキュメントを更新した

## スクリーンショット

## レビュアーに確認してほしいこと 
フロントエンドのテストが通ること
トップページ（ http://localhost:3000/ ）にアクセスしたときにNavBarが表示されずにサインインページに遷移すること

## 関連リンク
<!-- ソースコードに関連するファイルがあればリンクを共有 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ナビゲーションバーがユーザーの認証状態に基づいて条件付きで表示されるようになりました。ユーザーが未認証の場合、ナビゲーションバーは表示されません。
- **テスト**
	- ナビゲーションバーのテストケースが更新され、ユーザー情報が正しく表示されることを確認するためにモックが改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->