### PR TITLE
フロント：動画音声ファイルのアップロード

### DIFF
--- a/frontend-nextjs/__tests__/features/auth/dashboard/fileupload/FileUpload.test.tsx
+++ b/frontend-nextjs/__tests__/features/auth/dashboard/fileupload/FileUpload.test.tsx
@@ -25,7 +25,7 @@ describe("FileUploadComponent", () => {
 		render(<FileUploadComponent />);
 		expect(
 			screen.getByText(
-				/PDF、PNG、JPEGファイルをドラッグ＆ドロップするか、クリックして選択してください/,
+				/PDF、PNG、JPEG、MP4、MP3、WAVファイルをドラッグ＆ドロップするか、クリックして選択してください/,
 			),
 		).toBeInTheDocument();
 	});
@@ -34,7 +34,7 @@ describe("FileUploadComponent", () => {
 		render(<FileUploadComponent />);
 
 		const dropArea = screen.getByText(
-			/PDF、PNG、JPEGファイルをドラッグ＆ドロップするか、クリックして選択してください/,
+			/PDF、PNG、JPEG、MP4、MP3、WAVファイルをドラッグ＆ドロップするか、クリックして選択してください/,
 		);
 
 		const file = new File(["file content"], "test.pdf", {
@@ -56,7 +56,7 @@ describe("FileUploadComponent", () => {
 		render(<FileUploadComponent />);
 
 		const dropArea = screen.getByText(
-			/PDF、PNG、JPEGファイルをドラッグ＆ドロップするか、クリックして選択してください/,
+			/PDF、PNG、JPEG、MP4、MP3、WAVファイルをドラッグ＆ドロップするか、クリックして選択してください/,
 		);
 
 		const file = new File(["file content"], "test.txt", { type: "text/plain" });
@@ -71,7 +71,7 @@ describe("FileUploadComponent", () => {
 
 		expect(
 			await screen.findByText(
-				/test.txt は許可されていないファイル形式です。PDF、PNG、JPEGファイルのみアップロード可能です。/,
+				/test.txt は許可されていないファイル形式です。PDF、PNG、JPEG、MP4、MP3、WAVファイルのみアップロード可能です。/,
 			),
 		).toBeInTheDocument();
 	});
@@ -80,7 +80,7 @@ describe("FileUploadComponent", () => {
 		render(<FileUploadComponent />);
 
 		const dropArea = screen.getByText(
-			/PDF、PNG、JPEGファイルをドラッグ＆ドロップするか、クリックして選択してください/,
+			/PDF、PNG、JPEG、MP4、MP3、WAVファイルをドラッグ＆ドロップするか、クリックして選択してください/,
 		);
 
 		const file = new File(["file content"], "test.pdf", {
@@ -116,7 +116,7 @@ describe("FileUploadComponent", () => {
 		render(<FileUploadComponent />);
 
 		const dropArea = screen.getByText(
-			/PDF、PNG、JPEGファイルをドラッグ＆ドロップするか、クリックして選択してください/,
+			/PDF、PNG、JPEG、MP4、MP3、WAVファイルをドラッグ＆ドロップするか、クリックして選択してください/,
 		);
 
 		const file = new File(["file content"], "test.pdf", {

--- a/frontend-nextjs/src/features/dashboard/fileupload/FileUpload.tsx
+++ b/frontend-nextjs/src/features/dashboard/fileupload/FileUpload.tsx
@@ -18,8 +18,23 @@ const FileUploadComponent: React.FC = () => {
 	const { uploadFiles, isUploading } = useFileUpload();
 
 	const isAllowedFile = (file: File): boolean => {
-		const allowedTypes = ["application/pdf", "image/png", "image/jpeg"];
-		const allowedExtensions = [".pdf", ".png", ".jpg", ".jpeg"];
+		const allowedTypes = [
+			"application/pdf",
+			"image/png",
+			"image/jpeg",
+			"video/mp4",
+			"audio/mpeg",
+			"audio/wav",
+		];
+		const allowedExtensions = [
+			".pdf",
+			".png",
+			".jpg",
+			".jpeg",
+			".mp4",
+			".mp3",
+			".wav",
+		];
 		return (
 			allowedTypes.includes(file.type) ||
 			allowedExtensions.some((ext) => file.name.toLowerCase().endsWith(ext))
@@ -59,7 +74,7 @@ const FileUploadComponent: React.FC = () => {
 					return true;
 				}
 				setErrorMessage(
-					`${file.name} は許可されていないファイル形式です。PDF、PNG、JPEGファイルのみアップロード可能です。`,
+					`${file.name} は許可されていないファイル形式です。PDF、PNG、JPEG、MP4、MP3、WAVファイルのみアップロード可能です。`,
 				);
 				setTimeout(() => setErrorMessage(""), 5000);
 				return false;
@@ -174,7 +189,7 @@ const FileUploadComponent: React.FC = () => {
 					/>
 				</svg>
 				<p className="mt-2 text-sm text-gray-500">
-					PDF、PNG、JPEGファイルをドラッグ＆ドロップするか、クリックして選択してください
+					PDF、PNG、JPEG、MP4、MP3、WAVファイルをドラッグ＆ドロップするか、クリックして選択してください
 				</p>
 			</div>
 


### PR DESCRIPTION
## Issue No.
#206 
resolve #206

## 影響範囲とその理由
フロントエンドで動画音声ファイル（MP4,MP3,WAVファイル）のアップロードができるように修正しました

## チェックリスト
<!-- 変更を行った際にチェックした項目にチェックを入れてください。 -->
- [X] 単体テストを実施した
- [ ] 統合テストを実施した
- [ ] ドキュメントを更新した

## スクリーンショット
<!-- UIの変更がある場合は、Before / Afterのスクリーンショットや動作が分かるGIFなどを添付してください。 -->

## レビュアーに確認してほしいこと 
フロントエンドのテストが通ること
アップロードした動画音声ファイルがGCSに格納されていること

## 関連リンク
<!-- ソースコードに関連するファイルがあればリンクを共有 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ファイルアップロードコンポーネントにPDF、PNG、JPEGに加えてMP4、MP3、WAVファイルのアップロードが可能になりました。
	- ドラッグ＆ドロップエリアのテキストが新しいファイル形式を反映するように更新されました。
- **バグ修正**
	- アップロードできないファイル形式に対するエラーメッセージが更新され、ユーザーに新しい受け入れ形式を明確に伝えるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->