### PR TITLE
Geminiへ動画音声ファイルをリクエスト出来るように修正

### DIFF
--- a/backend/Dockerfile.backend
+++ b/backend/Dockerfile.backend
@@ -5,6 +5,9 @@ ENV PYTHONPATH=/backend
 
 WORKDIR /backend
 
+# FFmpegのインストール
+RUN apt-get update && apt-get install -y ffmpeg
+
 # poetryのインストール
 RUN pip install --no-cache-dir poetry==1.8.3
 
@@ -24,4 +27,4 @@ COPY . /backend/
 
 EXPOSE 8000
 
-ENTRYPOINT ["poetry", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+ENTRYPOINT ["poetry", "run", "hypercorn", "app.main:app", "--bind", "0.0.0.0:8000", "--reload"]

--- a/backend/Dockerfile.cloud_backend
+++ b/backend/Dockerfile.cloud_backend
@@ -8,6 +8,9 @@ ENV PYTHONPATH=/backend
 # 作業ディレクトリの設定
 WORKDIR /backend
 
+# FFmpegのインストール
+RUN apt-get update && apt-get install -y ffmpeg
+
 # poetryのインストール
 RUN pip install --no-cache-dir poetry==1.8.3
 

--- a/backend/app/utils/claude_request_stream.py
+++ b/backend/app/utils/claude_request_stream.py
@@ -98,7 +98,7 @@ async def generate_content_stream(
     image_files: list[dict] = []
     prompt = """
         - #role: あなたは、わかりやすく丁寧に教えることで評判の大学の「AI教授」です。
-        - #input_files: 複数のファイルは、ソフトウェア工学の解説スライドです。
+        - #input_files: 複数のファイルは、大学・大学院の講義資料です。
         - #instruction: 複数のpdf, imageファイルを読み解いて、練習問題を作って下さい。
         - #style1: "4択の選択問題"を5問 + "穴埋め問題"を5問、合計10問出題してください。
         - #style2: 200文字程度の"記述式問題"を3問出題して下さい。

--- a/backend/app/utils/gemini_request_stream.py
+++ b/backend/app/utils/gemini_request_stream.py
@@ -58,7 +58,11 @@ def convert_mp4_to_mp3(bucket_name: str, file_name: str) -> bool:
     blob = bucket.blob(file_name)
     temp_dir = tempfile.gettempdir()
     normalized_file_name = os.path.normpath(file_name)
-    if not normalized_file_name or ".." in normalized_file_name or normalized_file_name.startswith("/"):
+    if (
+        not normalized_file_name
+        or ".." in normalized_file_name
+        or normalized_file_name.startswith("/")
+    ):
         raise ValueError("Invalid file name")
     mp4_file_path = os.path.join(temp_dir, normalized_file_name)
     os.makedirs(os.path.dirname(mp4_file_path), exist_ok=True)
@@ -67,7 +71,11 @@ def convert_mp4_to_mp3(bucket_name: str, file_name: str) -> bool:
     # MP4ファイルをMP3に変換
     mp3_file_name = file_name.replace(".mp4", ".mp3")
     normalized_mp3_file_name = os.path.normpath(mp3_file_name)
-    if not normalized_mp3_file_name or ".." in normalized_mp3_file_name or normalized_mp3_file_name.startswith("/"):
+    if (
+        not normalized_mp3_file_name
+        or ".." in normalized_mp3_file_name
+        or normalized_mp3_file_name.startswith("/")
+    ):
         raise ValueError("Invalid file name")
     mp3_file_path = os.path.join(temp_dir, normalized_mp3_file_name)
     os.makedirs(os.path.dirname(mp3_file_path), exist_ok=True)

--- a/backend/app/utils/gemini_request_stream.py
+++ b/backend/app/utils/gemini_request_stream.py
@@ -57,13 +57,19 @@ def convert_mp4_to_mp3(bucket_name: str, file_name: str) -> bool:
     bucket = client.bucket(bucket_name)
     blob = bucket.blob(file_name)
     temp_dir = tempfile.gettempdir()
-    mp4_file_path = os.path.join(temp_dir, file_name)
+    normalized_file_name = os.path.normpath(file_name)
+    if not normalized_file_name.startswith(temp_dir):
+        raise ValueError("Invalid file name")
+    mp4_file_path = os.path.join(temp_dir, normalized_file_name)
     os.makedirs(os.path.dirname(mp4_file_path), exist_ok=True)
     blob.download_to_filename(mp4_file_path)
 
     # MP4ファイルをMP3に変換
     mp3_file_name = file_name.replace(".mp4", ".mp3")
-    mp3_file_path = os.path.join(temp_dir, mp3_file_name)
+    normalized_mp3_file_name = os.path.normpath(mp3_file_name)
+    if not normalized_mp3_file_name.startswith(temp_dir):
+        raise ValueError("Invalid file name")
+    mp3_file_path = os.path.join(temp_dir, normalized_mp3_file_name)
     os.makedirs(os.path.dirname(mp3_file_path), exist_ok=True)
     mp3_file_path = f"/tmp/{file_name.replace('.mp4', '.mp3')}"
     (

--- a/backend/app/utils/gemini_request_stream.py
+++ b/backend/app/utils/gemini_request_stream.py
@@ -2,9 +2,11 @@ import asyncio
 import json
 import logging
 import os
+import tempfile
 import unicodedata
 from typing import AsyncGenerator
 
+import ffmpeg
 import vertexai
 from dotenv import load_dotenv
 from google.api_core.exceptions import (
@@ -48,6 +50,39 @@ def check_file_exists(bucket_name: str, file_name: str) -> bool:
     return blob.exists()
 
 
+# MP4のファイルをMP3に変換してGCSに保存
+def convert_mp4_to_mp3(bucket_name: str, file_name: str) -> bool:
+    # GCSからファイルを取得
+    client = storage.Client()
+    bucket = client.bucket(bucket_name)
+    blob = bucket.blob(file_name)
+    temp_dir = tempfile.gettempdir()
+    mp4_file_path = os.path.join(temp_dir, file_name)
+    os.makedirs(os.path.dirname(mp4_file_path), exist_ok=True)
+    blob.download_to_filename(mp4_file_path)
+
+    # MP4ファイルをMP3に変換
+    mp3_file_name = file_name.replace(".mp4", ".mp3")
+    mp3_file_path = os.path.join(temp_dir, mp3_file_name)
+    os.makedirs(os.path.dirname(mp3_file_path), exist_ok=True)
+    mp3_file_path = f"/tmp/{file_name.replace('.mp4', '.mp3')}"
+    (
+        ffmpeg.input(mp4_file_path)
+        .output(mp3_file_path, format="mp3", acodec="libmp3lame")
+        .run()
+    )
+
+    # MP3ファイルをGCSにアップロード
+    upload_file_name = f'mp3/{file_name.replace(".mp4", ".mp3")}'
+    mp3_blob = bucket.blob(upload_file_name)
+    mp3_blob.upload_from_filename(mp3_file_path)
+
+    # 一時ファイルを削除
+    os.remove(mp4_file_path)
+    os.remove(mp3_file_path)
+    return mp3_blob.exists()
+
+
 # 複数のPDF, imageファイルを入力してコンテンツを生成
 async def generate_content_stream(
     files: list[str],
@@ -58,12 +93,15 @@ async def generate_content_stream(
 ) -> AsyncGenerator[GenerationResponse, None]:
     pdf_files: list[Part] = []
     image_files: list[Part] = []
+    mp3_files: list[Part] = []
+    wav_files: list[Part] = []
     # プロンプト（指示文）
     prompt = """
         - #role: あなたは、わかりやすく丁寧に教えることで評判の大学の「AI教授」です。
-        - #input_files: 複数のファイルは、ソフトウェア工学の解説スライドです。
-        - #instruction: 複数のpdf, imageファイルを読み解いて、親しみやすい解説がついて、
-            誰もが読みたくなるような、わかりやすい整理ノートを日本語で作成して下さい。
+        - #input_files: 複数のファイルは、大学・大学院の講義資料です。
+        - #instruction: 複数のpdf, image、audioファイルを読み解いて、
+            親しみやすい解説がついて、誰もが読みたくなるような、
+            わかりやすい整理ノートを日本語で作成して下さい。
             imageファイルが複数ある場合、それぞれの画像に対して解説を行ってください。
         - #style: ビジュアル的にもわかりやすくするため、マークダウンで文字の大きさ、
             強調表示などのスタイルを追加してください。
@@ -107,14 +145,36 @@ async def generate_content_stream(
                     # imageファイルのパートを作成
                     image_file = Part.from_uri(image_file_uri, mime_type="image/png")
                     image_files.append(image_file)
+                elif file_name.endswith("mp4"):
+                    # ファイルを音声ファイルに変換する
+                    if convert_mp4_to_mp3(bucket_name, file_name):
+                        logging.info(f"File {file_name} is converted to MP3.")
+                        # 音声ファイルに変換したファイルのURL
+                        mp3_file_name = file_name.replace(".mp4", ".mp3")
+                        mp3_file_url = f"gs://{bucket_name}/mp3/{mp3_file_name}"
+                        # 音声ファイルのパートを作成
+                        mp3_file = Part.from_uri(mp3_file_url, mime_type="audio/mp3")
+                        mp3_files.append(mp3_file)
+                elif file_name.endswith("mp3"):
+                    # 音声ファイルのURL
+                    mp3_file_url = f"gs://{bucket_name}/{file_name}"
+                    # 音声ファイルのパートを作成
+                    mp3_file = Part.from_uri(mp3_file_url, mime_type="audio/mp3")
+                    mp3_files.append(mp3_file)
+                elif file_name.endswith("wav"):
+                    # 音声ファイルのURL
+                    wav_file_url = f"gs://{bucket_name}/{file_name}"
+                    # 音声ファイルのパートを作成
+                    wav_file = Part.from_uri(wav_file_url, mime_type="audio/wav")
+                    wav_files.append(wav_file)
                 else:
                     logging.error(
                         f"Invalid file format: {file_name}. "
-                        + "Only PDF and image files are supported."
+                        + "Only PDF and image and audio files are supported."
                     )
                     raise InvalidArgument(
                         f"Invalid file format: {file_name}. "
-                        + "Only PDF and image files are supported."
+                        + "Only PDF and image and audio files are supported."
                     )
             else:
                 logging.error(
@@ -140,7 +200,7 @@ async def generate_content_stream(
         model = GenerativeModel(model_name=model_name)
 
         # コンテンツリストを作成
-        contents = pdf_files + image_files + [prompt]
+        contents = pdf_files + image_files + mp3_files + wav_files + [prompt]
 
         # 同期関数を非同期にラップする
         sync_response = await asyncio.to_thread(

--- a/backend/app/utils/gemini_request_stream.py
+++ b/backend/app/utils/gemini_request_stream.py
@@ -58,7 +58,7 @@ def convert_mp4_to_mp3(bucket_name: str, file_name: str) -> bool:
     blob = bucket.blob(file_name)
     temp_dir = tempfile.gettempdir()
     normalized_file_name = os.path.normpath(file_name)
-    if not normalized_file_name.startswith(temp_dir):
+    if not normalized_file_name or ".." in normalized_file_name or normalized_file_name.startswith("/"):
         raise ValueError("Invalid file name")
     mp4_file_path = os.path.join(temp_dir, normalized_file_name)
     os.makedirs(os.path.dirname(mp4_file_path), exist_ok=True)
@@ -67,11 +67,11 @@ def convert_mp4_to_mp3(bucket_name: str, file_name: str) -> bool:
     # MP4ファイルをMP3に変換
     mp3_file_name = file_name.replace(".mp4", ".mp3")
     normalized_mp3_file_name = os.path.normpath(mp3_file_name)
-    if not normalized_mp3_file_name.startswith(temp_dir):
+    if not normalized_mp3_file_name or ".." in normalized_mp3_file_name or normalized_mp3_file_name.startswith("/"):
         raise ValueError("Invalid file name")
     mp3_file_path = os.path.join(temp_dir, normalized_mp3_file_name)
     os.makedirs(os.path.dirname(mp3_file_path), exist_ok=True)
-    mp3_file_path = f"/tmp/{file_name.replace('.mp4', '.mp3')}"
+    mp3_file_path = os.path.join(temp_dir, normalized_mp3_file_name)
     (
         ffmpeg.input(mp4_file_path)
         .output(mp3_file_path, format="mp3", acodec="libmp3lame")

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -5,4 +5,4 @@ set -e
 poetry run python -m app.migrate_cloud_db
 
 # FastAPIサーバーを起動
-poetry run uvicorn app.main:app --host 0.0.0.0
+poetry run hypercorn app.main:app --bind 0.0.0.0

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -527,6 +527,23 @@ all = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "httpx (>
 standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "httpx (>=0.23.0)", "jinja2 (>=2.11.2)", "python-multipart (>=0.0.7)", "uvicorn[standard] (>=0.12.0)"]
 
 [[package]]
+name = "ffmpeg-python"
+version = "0.2.0"
+description = "Python bindings for FFmpeg - with complex filtering support"
+optional = false
+python-versions = "*"
+files = [
+    {file = "ffmpeg-python-0.2.0.tar.gz", hash = "sha256:65225db34627c578ef0e11c8b1eb528bb35e024752f6f10b78c011f6f64c4127"},
+    {file = "ffmpeg_python-0.2.0-py3-none-any.whl", hash = "sha256:ac441a0404e053f8b6a1113a77c0f452f1cfc62f6344a769475ffdc0f56c23c5"},
+]
+
+[package.dependencies]
+future = "*"
+
+[package.extras]
+dev = ["Sphinx (==2.1.0)", "future (==0.17.1)", "numpy (==1.16.4)", "pytest (==4.6.1)", "pytest-mock (==1.10.4)", "tox (==3.12.1)"]
+
+[[package]]
 name = "filelock"
 version = "3.15.4"
 description = "A platform independent file lock."
@@ -599,6 +616,17 @@ test = ["aiohttp (!=4.0.0a0,!=4.0.0a1)", "numpy", "pytest", "pytest-asyncio (!=0
 test-downstream = ["aiobotocore (>=2.5.4,<3.0.0)", "dask-expr", "dask[dataframe,test]", "moto[server] (>4,<5)", "pytest-timeout", "xarray"]
 test-full = ["adlfs", "aiohttp (!=4.0.0a0,!=4.0.0a1)", "cloudpickle", "dask", "distributed", "dropbox", "dropboxdrivefs", "fastparquet", "fusepy", "gcsfs", "jinja2", "kerchunk", "libarchive-c", "lz4", "notebook", "numpy", "ocifs", "pandas", "panel", "paramiko", "pyarrow", "pyarrow (>=1)", "pyftpdlib", "pygit2", "pytest", "pytest-asyncio (!=0.22.0)", "pytest-benchmark", "pytest-cov", "pytest-mock", "pytest-recording", "pytest-rerunfailures", "python-snappy", "requests", "smbprotocol", "tqdm", "urllib3", "zarr", "zstandard"]
 tqdm = ["tqdm"]
+
+[[package]]
+name = "future"
+version = "1.0.0"
+description = "Clean single-source support for Python 3 and 2"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "future-1.0.0-py3-none-any.whl", hash = "sha256:929292d34f5872e70396626ef385ec22355a1fae8ad29e1a734c3e43f9fbc216"},
+    {file = "future-1.0.0.tar.gz", hash = "sha256:bd2968309307861edae1458a4f8a4f3598c03be43b97521076aebf5d94c07b05"},
+]
 
 [[package]]
 name = "google-api-core"
@@ -1124,6 +1152,32 @@ files = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.1.0"
+description = "HTTP/2 State-Machine based protocol implementation"
+optional = false
+python-versions = ">=3.6.1"
+files = [
+    {file = "h2-4.1.0-py3-none-any.whl", hash = "sha256:03a46bcf682256c95b5fd9e9a99c1323584c3eec6440d379b9903d709476bc6d"},
+    {file = "h2-4.1.0.tar.gz", hash = "sha256:a83aca08fbe7aacb79fec788c9c0bac936343560ed9ec18b82a13a12c28d2abb"},
+]
+
+[package.dependencies]
+hpack = ">=4.0,<5"
+hyperframe = ">=6.0,<7"
+
+[[package]]
+name = "hpack"
+version = "4.0.0"
+description = "Pure-Python HPACK header compression"
+optional = false
+python-versions = ">=3.6.1"
+files = [
+    {file = "hpack-4.0.0-py3-none-any.whl", hash = "sha256:84a076fad3dc9a9f8063ccb8041ef100867b1878b25ef0ee63847a5d53818a6c"},
+    {file = "hpack-4.0.0.tar.gz", hash = "sha256:fc41de0c63e687ebffde81187a948221294896f6bdc0ae2312708df339430095"},
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.5"
 description = "A minimal low-level HTTP client."
@@ -1263,6 +1317,40 @@ tensorflow-testing = ["keras (<3.0)", "tensorflow"]
 testing = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "fastapi", "gradio", "jedi", "minijinja (>=1.0)", "numpy", "pytest", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-rerunfailures", "pytest-vcr", "pytest-xdist", "soundfile", "urllib3 (<2.0)"]
 torch = ["safetensors", "torch"]
 typing = ["types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)"]
+
+[[package]]
+name = "hypercorn"
+version = "0.17.3"
+description = "A ASGI Server based on Hyper libraries and inspired by Gunicorn"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "hypercorn-0.17.3-py3-none-any.whl", hash = "sha256:059215dec34537f9d40a69258d323f56344805efb462959e727152b0aa504547"},
+    {file = "hypercorn-0.17.3.tar.gz", hash = "sha256:1b37802ee3ac52d2d85270700d565787ab16cf19e1462ccfa9f089ca17574165"},
+]
+
+[package.dependencies]
+h11 = "*"
+h2 = ">=3.1.0"
+priority = "*"
+wsproto = ">=0.14.0"
+
+[package.extras]
+docs = ["pydata_sphinx_theme", "sphinxcontrib_mermaid"]
+h3 = ["aioquic (>=0.9.0,<1.0)"]
+trio = ["trio (>=0.22.0)"]
+uvloop = ["uvloop (>=0.18)"]
+
+[[package]]
+name = "hyperframe"
+version = "6.0.1"
+description = "HTTP/2 framing layer for Python"
+optional = false
+python-versions = ">=3.6.1"
+files = [
+    {file = "hyperframe-6.0.1-py3-none-any.whl", hash = "sha256:0ec6bafd80d8ad2195c4f03aacba3a8265e57bc4cff261e802bf39970ed02a15"},
+    {file = "hyperframe-6.0.1.tar.gz", hash = "sha256:ae510046231dc8e9ecb1a6586f63d2347bf4c8905914aa84ba585ae85f28a914"},
+]
 
 [[package]]
 name = "idna"
@@ -1794,6 +1882,17 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "priority"
+version = "2.0.0"
+description = "A pure-Python implementation of the HTTP/2 priority tree"
+optional = false
+python-versions = ">=3.6.1"
+files = [
+    {file = "priority-2.0.0-py3-none-any.whl", hash = "sha256:6f8eefce5f3ad59baf2c080a664037bb4725cd0a790d53d59ab4059288faf6aa"},
+    {file = "priority-2.0.0.tar.gz", hash = "sha256:c965d54f1b8d0d0b19479db3924c7c36cf672dbf2aec92d43fbdaf4492ba18c0"},
+]
 
 [[package]]
 name = "proto-plus"
@@ -3121,7 +3220,21 @@ files = [
     {file = "websockets-12.0.tar.gz", hash = "sha256:81df9cbcbb6c260de1e007e58c011bfebe2dafc8435107b0537f393dd38c8b1b"},
 ]
 
+[[package]]
+name = "wsproto"
+version = "1.2.0"
+description = "WebSockets state-machine based protocol implementation"
+optional = false
+python-versions = ">=3.7.0"
+files = [
+    {file = "wsproto-1.2.0-py3-none-any.whl", hash = "sha256:b9acddd652b585d75b20477888c56642fdade28bdfd3579aa24a4d2c037dd736"},
+    {file = "wsproto-1.2.0.tar.gz", hash = "sha256:ad565f26ecb92588a3e43bc3d96164de84cd9902482b130d0ddbaa9664a85065"},
+]
+
+[package.dependencies]
+h11 = ">=0.9.0,<1"
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "739dc6a493cfb269cc8dc67bcf1c70497a201998a74db4ab4a2726762b030135"
+content-hash = "949349f326d4eb502c5d136b3eb6f64157db2840a09ff45ceca0b61fde6aff30"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -28,6 +28,8 @@ sphinx-rtd-theme = "^2.0.0"
 myst-parser = "^3.0.1"
 firebase-admin = "^6.5.0"
 starlette = "0.40.0"
+ffmpeg-python = "^0.2.0"
+hypercorn = "^0.17.3"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/frontend-nextjs/__tests__/features/auth/dashboard/fileupload/FileUpload.test.tsx
+++ b/frontend-nextjs/__tests__/features/auth/dashboard/fileupload/FileUpload.test.tsx
@@ -25,7 +25,7 @@ describe("FileUploadComponent", () => {
 		render(<FileUploadComponent />);
 		expect(
 			screen.getByText(
-				/PDF、PNG、JPEGファイルをドラッグ＆ドロップするか、クリックして選択してください/,
+				/PDF、PNG、JPEG、MP4、MP3、WAVファイルをドラッグ＆ドロップするか、クリックして選択してください/,
 			),
 		).toBeInTheDocument();
 	});
@@ -34,7 +34,7 @@ describe("FileUploadComponent", () => {
 		render(<FileUploadComponent />);
 
 		const dropArea = screen.getByText(
-			/PDF、PNG、JPEGファイルをドラッグ＆ドロップするか、クリックして選択してください/,
+			/PDF、PNG、JPEG、MP4、MP3、WAVファイルをドラッグ＆ドロップするか、クリックして選択してください/,
 		);
 
 		const file = new File(["file content"], "test.pdf", {
@@ -56,7 +56,7 @@ describe("FileUploadComponent", () => {
 		render(<FileUploadComponent />);
 
 		const dropArea = screen.getByText(
-			/PDF、PNG、JPEGファイルをドラッグ＆ドロップするか、クリックして選択してください/,
+			/PDF、PNG、JPEG、MP4、MP3、WAVファイルをドラッグ＆ドロップするか、クリックして選択してください/,
 		);
 
 		const file = new File(["file content"], "test.txt", { type: "text/plain" });
@@ -71,7 +71,7 @@ describe("FileUploadComponent", () => {
 
 		expect(
 			await screen.findByText(
-				/test.txt は許可されていないファイル形式です。PDF、PNG、JPEGファイルのみアップロード可能です。/,
+				/test.txt は許可されていないファイル形式です。PDF、PNG、JPEG、MP4、MP3、WAVファイルのみアップロード可能です。/,
 			),
 		).toBeInTheDocument();
 	});
@@ -80,7 +80,7 @@ describe("FileUploadComponent", () => {
 		render(<FileUploadComponent />);
 
 		const dropArea = screen.getByText(
-			/PDF、PNG、JPEGファイルをドラッグ＆ドロップするか、クリックして選択してください/,
+			/PDF、PNG、JPEG、MP4、MP3、WAVファイルをドラッグ＆ドロップするか、クリックして選択してください/,
 		);
 
 		const file = new File(["file content"], "test.pdf", {
@@ -116,7 +116,7 @@ describe("FileUploadComponent", () => {
 		render(<FileUploadComponent />);
 
 		const dropArea = screen.getByText(
-			/PDF、PNG、JPEGファイルをドラッグ＆ドロップするか、クリックして選択してください/,
+			/PDF、PNG、JPEG、MP4、MP3、WAVファイルをドラッグ＆ドロップするか、クリックして選択してください/,
 		);
 
 		const file = new File(["file content"], "test.pdf", {

--- a/frontend-nextjs/src/features/dashboard/fileupload/FileUpload.tsx
+++ b/frontend-nextjs/src/features/dashboard/fileupload/FileUpload.tsx
@@ -18,8 +18,23 @@ const FileUploadComponent: React.FC = () => {
 	const { uploadFiles, isUploading } = useFileUpload();
 
 	const isAllowedFile = (file: File): boolean => {
-		const allowedTypes = ["application/pdf", "image/png", "image/jpeg"];
-		const allowedExtensions = [".pdf", ".png", ".jpg", ".jpeg"];
+		const allowedTypes = [
+			"application/pdf",
+			"image/png",
+			"image/jpeg",
+			"video/mp4",
+			"audio/mpeg",
+			"audio/wav",
+		];
+		const allowedExtensions = [
+			".pdf",
+			".png",
+			".jpg",
+			".jpeg",
+			".mp4",
+			".mp3",
+			".wav",
+		];
 		return (
 			allowedTypes.includes(file.type) ||
 			allowedExtensions.some((ext) => file.name.toLowerCase().endsWith(ext))
@@ -59,7 +74,7 @@ const FileUploadComponent: React.FC = () => {
 					return true;
 				}
 				setErrorMessage(
-					`${file.name} は許可されていないファイル形式です。PDF、PNG、JPEGファイルのみアップロード可能です。`,
+					`${file.name} は許可されていないファイル形式です。PDF、PNG、JPEG、MP4、MP3、WAVファイルのみアップロード可能です。`,
 				);
 				setTimeout(() => setErrorMessage(""), 5000);
 				return false;
@@ -174,7 +189,7 @@ const FileUploadComponent: React.FC = () => {
 					/>
 				</svg>
 				<p className="mt-2 text-sm text-gray-500">
-					PDF、PNG、JPEGファイルをドラッグ＆ドロップするか、クリックして選択してください
+					PDF、PNG、JPEG、MP4、MP3、WAVファイルをドラッグ＆ドロップするか、クリックして選択してください
 				</p>
 			</div>
 


### PR DESCRIPTION
## Issue No.
#207 
resolve #207 

## 影響範囲とその理由
GCSからmp4ファイルを取得して、mp3に変換
その後MP3ファイルをGCSに再アップロードしてからGeminiにリクエストを送っています
その際にGCSのディレクトリの先頭に"mp3"と付けて、既存のmp3ファイルを上書きしないようにしています

またCloud Runの制限を回避するために、uvicornからhypercornに変更しています

## チェックリスト
<!-- 変更を行った際にチェックした項目にチェックを入れてください。 -->
- [X] 単体テストを実施した
- [ ] 統合テストを実施した
- [ ] ドキュメントを更新した

## スクリーンショット
<!-- UIの変更がある場合は、Before / Afterのスクリーンショットや動作が分かるGIFなどを添付してください。 -->

## レビュアーに確認してほしいこと 
バックエンドのテストが通ること
mp4ファイルでAI出力が作成出来ること

## 関連リンク
<!-- ソースコードに関連するファイルがあればリンクを共有 -->
