### PR TITLE
フロントエンド：ノートの詳細ページを削除した際にノートリストに戻る

### DIFF
--- a/frontend-nextjs/src/features/dashboard/notebook/components/DeleteButton.tsx
+++ b/frontend-nextjs/src/features/dashboard/notebook/components/DeleteButton.tsx
@@ -14,7 +14,7 @@ export const DeleteButton = ({ noteId, onDelete }: DeleteButtonProps) => {
 	const handleDelete = async () => {
 		try {
 			await deleteNotebook(noteId);
-			router.push("/");
+			router.push("/select-notes");
 		} catch (error) {
 			console.error("削除エラー:", error);
 		}


### PR DESCRIPTION
## Issue No.
#275
resolve #275

## 影響範囲とその理由
<!-- この変更により起こり得る影響範囲とその理由を書いてください。 -->

## チェックリスト
<!-- 変更を行った際にチェックした項目にチェックを入れてください。 -->
- [X] 単体テストを実施した
- [ ] 統合テストを実施した
- [ ] ドキュメントを更新した

## スクリーンショット
<!-- UIの変更がある場合は、Before / Afterのスクリーンショットや動作が分かるGIFなどを添付してください。 -->

## レビュアーに確認してほしいこと 
- フロントエンドのテストが通ること
- ノートの詳細ページ（not リストページ）でノートを削除した後にトップページではなくノートリストのページに遷移する

## 関連リンク
<!-- ソースコードに関連するファイルがあればリンクを共有 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ノートブックの削除後に、ユーザーが`"/select-notes"`ページにリダイレクトされるように変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->