### PR TITLE
フロントエンド：（AI要約/AI練習問題の）リスト以外のリンクをサイドバーから削除 

### DIFF
--- a/frontend-nextjs/__tests__/components/layouts/NavBar.test.tsx
+++ b/frontend-nextjs/__tests__/components/layouts/NavBar.test.tsx
@@ -137,17 +137,13 @@ describe("NavBar", () => {
 		expect(screen.getByText("ファイル選択")).toBeInTheDocument();
 	});
 
-	it("AI要約グループが展開されること", () => {
+	it("AI要約メニュー項目が表示されること", () => {
 		render(<NavBar />);
-		const groupHeader = screen.getByTestId("accordion-header-AI要約");
-		fireEvent.click(groupHeader);
 		expect(screen.getByText("AI要約リスト")).toBeInTheDocument();
 	});
 
-	it("AI練習問題グループが展開されること", () => {
+	it("AI練習問題メニュー項目が表示されること", () => {
 		render(<NavBar />);
-		const groupHeader = screen.getByTestId("accordion-header-AI練習問題");
-		fireEvent.click(groupHeader);
 		expect(screen.getByText("AI練習問題リスト")).toBeInTheDocument();
 	});
 

--- a/frontend-nextjs/src/components/layouts/NavBar.tsx
+++ b/frontend-nextjs/src/components/layouts/NavBar.tsx
@@ -41,49 +41,11 @@ const groupIcons: Record<
 	string,
 	React.ComponentType<{ className?: string }>
 > = {
-	AI要約: DocumentTextIcon,
-	AI練習問題: QuestionMarkCircleIcon,
 	ノート: BookOpenIcon,
 };
 
 // Define navigation groups
 const navigationGroups = [
-	{
-		name: "AI要約",
-		items: [
-			{
-				name: "AI要約リスト",
-				href: "/ai-output/select-ai-output",
-				icon: ListBulletIcon,
-			},
-			{ name: "AI要約", href: "/ai-output/stream", icon: ComputerDesktopIcon },
-		],
-	},
-	{
-		name: "AI練習問題",
-		items: [
-			{
-				name: "AI練習問題リスト",
-				href: "/ai-exercise/select-exercises",
-				icon: ListBulletIcon,
-			},
-			{
-				name: "AI練習問題",
-				href: "/ai-exercise/stream",
-				icon: PencilSquareIcon,
-			},
-			{
-				name: "選択問題テスト",
-				href: "/ai-exercise/multiple-choice",
-				icon: DocumentCheckIcon,
-			},
-			{
-				name: "記述問題テスト",
-				href: "/ai-exercise/essay-question",
-				icon: DocumentCheckIcon,
-			},
-		],
-	},
 	{
 		name: "ノート",
 		items: [
@@ -150,6 +112,22 @@ export default function NavBar() {
 							<FolderIcon className="h-5 w-5" />
 						</ListItemPrefix>
 						ファイル選択
+					</ListItem>
+				</Link>
+				<Link href="/ai-output/select-ai-output">
+					<ListItem>
+						<ListItemPrefix>
+							<ListBulletIcon className="h-5 w-5" />
+						</ListItemPrefix>
+						AI要約リスト
+					</ListItem>
+				</Link>
+				<Link href="/ai-exercise/select-exercises">
+					<ListItem>
+						<ListItemPrefix>
+							<ListBulletIcon className="h-5 w-5" />
+						</ListItemPrefix>
+						AI練習問題リスト
 					</ListItem>
 				</Link>
 


### PR DESCRIPTION
## Issue No.
#279 
resolve #279 

## 影響範囲とその理由
（AI要約/AI練習問題の）リスト以外のリンクをサイドバーから削除 
合わせてAI要約とAI練習問題のグループ化も解除しています

## チェックリスト
<!-- 変更を行った際にチェックした項目にチェックを入れてください。 -->
- [X] 単体テストを実施した
- [ ] 統合テストを実施した
- [ ] ドキュメントを更新した

## スクリーンショット
![スクリーンショット 2024-12-25 20 19 04](https://github.com/user-attachments/assets/a3f50a10-d680-4e38-bdd0-5bb304982afd)


## レビュアーに確認してほしいこと 
- フロントエンドのテストが通ること
- サイドバーから（AI要約/AI練習問題の）リスト以外のリンクをサイドバーから削除 されていること

## 関連リンク
<!-- ソースコードに関連するファイルがあればリンクを共有 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ナビゲーションバーに新しい直接リンク「AI要約リスト」と「AI練習問題リスト」を追加しました。

- **バグ修正**
  - ナビゲーショングループ「AI要約」と「AI練習問題」およびその関連項目を削除しました。

- **テスト**
  - テストケースの名称を変更し、メニュー項目の表示を確認するようにテストを修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->