### PR TITLE
メニュー・ヘッダーの表示修正

### DIFF
--- a/frontend-nextjs/__tests__/features/dashboard/ai-output/stream/OutputDisplay.test.tsx
+++ b/frontend-nextjs/__tests__/features/dashboard/ai-output/stream/OutputDisplay.test.tsx
@@ -63,6 +63,6 @@ describe("OutputDisplay", () => {
 		expect(screen.getByTestId("card")).toBeInTheDocument();
 		expect(screen.getByTestId("card-header")).toBeInTheDocument();
 		expect(screen.getByTestId("card-body")).toBeInTheDocument();
-		expect(screen.getByText("AI ノート")).toBeInTheDocument();
+		expect(screen.getByText("AI 要約")).toBeInTheDocument();
 	});
 });

--- a/frontend-nextjs/__tests__/features/dashboard/select-files/FileSelectComponent.test.tsx
+++ b/frontend-nextjs/__tests__/features/dashboard/select-files/FileSelectComponent.test.tsx
@@ -98,7 +98,7 @@ describe("FileSelectComponent", () => {
 
 		// タイトルを入力
 		const titleInput = screen.getByPlaceholderText(
-			"AI要約/演習のタイトルを入力してください（最大100文字）",
+			"AI要約/練習問題のタイトルを入力してください（最大100文字）",
 		);
 		fireEvent.change(titleInput, { target: { value: "テストノート" } });
 
@@ -116,7 +116,7 @@ describe("FileSelectComponent", () => {
 		});
 	});
 
-	it("ファイルを選択して演習問題を作成できること", async () => {
+	it("ファイルを選択して練習問題を作成できること", async () => {
 		render(<FileSelectComponent />);
 
 		await waitFor(() => {
@@ -127,7 +127,7 @@ describe("FileSelectComponent", () => {
 		fireEvent.click(checkboxes[1]);
 
 		const titleInput = screen.getByPlaceholderText(
-			"AI要約/演習のタイトルを入力してください（最大100文字）",
+			"AI要約/練習問題のタイトルを入力してください（最大100文字）",
 		);
 		fireEvent.change(titleInput, { target: { value: "テスト演習" } });
 
@@ -153,7 +153,7 @@ describe("FileSelectComponent", () => {
 		fireEvent.click(checkboxes[1]);
 
 		const titleInput = screen.getByPlaceholderText(
-			"AI要約/演習のタイトルを入力してください（最大100文字）",
+			"AI要約/練習問題のタイトルを入力してください（最大100文字）",
 		);
 		fireEvent.change(titleInput, { target: { value: "テスト選択問題" } });
 

--- a/frontend-nextjs/src/features/dashboard/ai-output/stream/GetAIOutputDisplay.tsx
+++ b/frontend-nextjs/src/features/dashboard/ai-output/stream/GetAIOutputDisplay.tsx
@@ -123,7 +123,7 @@ export function GetAIOutputDisplay({ outputId }: Props) {
 				<CardHeader className="mb-4 grid h-28 place-items-center border-b border-gray-200">
 					<div className="flex flex-col items-center gap-2">
 						<Typography variant="h3" className="text-gray-900">
-							AI 出力
+							AI 要約
 						</Typography>
 						{output.title && (
 							<Typography variant="h5" className="text-gray-700">

--- a/frontend-nextjs/src/features/dashboard/ai-output/stream/OutputDisplay.tsx
+++ b/frontend-nextjs/src/features/dashboard/ai-output/stream/OutputDisplay.tsx
@@ -21,7 +21,7 @@ export function OutputDisplay({ loading, error, output }: OutputDisplayProps) {
 		<Card className="w-full">
 			<CardHeader className="mb-4 grid h-28 place-items-center border-b border-gray-200">
 				<Typography variant="h3" className="text-gray-900">
-					AI ノート
+					AI 要約
 				</Typography>
 			</CardHeader>
 			<CardBody className="flex flex-col gap-4">

--- a/frontend-nextjs/src/features/dashboard/select-files/FileSelectComponent.tsx
+++ b/frontend-nextjs/src/features/dashboard/select-files/FileSelectComponent.tsx
@@ -237,7 +237,7 @@ export default function FileSelectComponent() {
 			<Card className="w-full">
 				<CardHeader className="mb-4 grid h-28 place-items-center border-b border-gray-200">
 					<Typography variant="h3" className="text-gray-900">
-						AI 要約/練習問題
+						ファイル選択
 					</Typography>
 				</CardHeader>
 

--- a/frontend-nextjs/src/features/dashboard/select-files/FileSelectComponent.tsx
+++ b/frontend-nextjs/src/features/dashboard/select-files/FileSelectComponent.tsx
@@ -237,7 +237,7 @@ export default function FileSelectComponent() {
 			<Card className="w-full">
 				<CardHeader className="mb-4 grid h-28 place-items-center border-b border-gray-200">
 					<Typography variant="h3" className="text-gray-900">
-						AI ノート/練習問題
+						AI 要約/練習問題
 					</Typography>
 				</CardHeader>
 
@@ -328,7 +328,7 @@ export default function FileSelectComponent() {
 								<Input
 									value={title}
 									onChange={(e) => setTitle(e.target.value)}
-									placeholder="AI要約/演習のタイトルを入力してください（最大100文字）"
+									placeholder="AI要約/練習問題のタイトルを入力してください（最大100文字）"
 									maxLength={100}
 									className="mt-1 focus:outline-none !border !border-gray-300 focus:!border-gray-900 rounded-lg"
 									labelProps={{


### PR DESCRIPTION
## Issue No.
#278 

resolve #278 

## 影響範囲とその理由
ファイル選択ページのヘッダー名を「AI ノート/練習問題」から「ファイル選択」に変更
ファイル選択ページのタイトル入力エリアの説明を「AI 要約/演習」から「AI 要約/練習問題」に変更
AI要約ページのヘッダー名を「AIノート」もしくは「AI出力」から「AI要約」に変更

## チェックリスト
<!-- 変更を行った際にチェックした項目にチェックを入れてください。 -->
- [X] 単体テストを実施した
- [ ] 統合テストを実施した
- [ ] ドキュメントを更新した

## スクリーンショット
![スクリーンショット 2024-12-26 19 51 35](https://github.com/user-attachments/assets/a07e71dd-8fbe-420e-af76-f7b51d20a85d)
![スクリーンショット 2024-12-26 19 52 01](https://github.com/user-attachments/assets/f593ca30-acd9-42a0-98dc-f8c2200add8c)
![スクリーンショット 2024-12-26 19 53 59](https://github.com/user-attachments/assets/61d74167-929f-4b71-aa9d-7e7e2091c823)


## レビュアーに確認してほしいこと 
 - フロントエンドのテストが通ること
 - スクリーンショットの変更が反映されていること

## 関連リンク
<!-- ソースコードに関連するファイルがあればリンクを共有 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - コンポーネントの表示テキストを「AI ノート」から「AI 要約」に変更。
  - 「演習」を「練習問題」に置き換えたプレースホルダーテキストを更新。

- **バグ修正**
  - テストケースの期待されるテキスト内容を修正。

- **スタイル**
  - コンポーネントのメインタイトルを「AI ノート/練習問題」から「ファイル選択」に変更。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->