### PR TITLE
ファイル選択画面の修正

### DIFF
--- a/frontend-nextjs/src/features/dashboard/select-files/FileSelectComponent.tsx
+++ b/frontend-nextjs/src/features/dashboard/select-files/FileSelectComponent.tsx
@@ -314,72 +314,64 @@ export default function FileSelectComponent() {
 						<Alert variant="gradient">ファイルが見つかりません</Alert>
 					)}
 
-					{isAnyFileSelected && (
-						<div className="space-y-4">
-							<div>
-								<Typography variant="h6">選択されたファイル</Typography>
-								<Typography variant="small" className="text-gray-600">
-									{selectedFileNames}
-								</Typography>
-							</div>
-
-							<div>
-								<Typography variant="h6">タイトル</Typography>
-								<Input
-									value={title}
-									onChange={(e) => setTitle(e.target.value)}
-									placeholder="AI要約/練習問題のタイトルを入力してください（最大100文字）"
-									maxLength={100}
-									className="mt-1 focus:outline-none !border !border-gray-300 focus:!border-gray-900 rounded-lg"
-									labelProps={{
-										className: "before:content-none after:content-none",
-									}}
-									disabled={loading}
-								/>
-							</div>
-
-							{title && (
-								<div className="flex gap-4">
-									<Button
-										size="lg"
-										onClick={() => createAiContent("ai-output/stream")}
-										className="flex-1"
-										disabled={loading}
-									>
-										AI要約作成
-									</Button>
-									<Button
-										size="lg"
-										onClick={() => createAiContent("ai-exercise/stream")}
-										className="flex-1"
-										disabled={loading}
-									>
-										AI練習問題
-									</Button>
-									<Button
-										size="lg"
-										onClick={() =>
-											createAiContent("ai-exercise/multiple-choice")
-										}
-										className="flex-1"
-										disabled={loading}
-									>
-										選択問題テスト
-									</Button>
-									<Button
-										size="lg"
-										onClick={() =>
-											createAiContent("ai-exercise/essay-question")
-										}
-										className="flex-1"
-										disabled={loading}
-									>
-										記述問題テスト
-									</Button>
-								</div>
-							)}
+					<div className="space-y-4">
+						<div>
+							<Typography variant="h6">選択されたファイル</Typography>
+							<Typography variant="small" className="text-gray-600">
+								{selectedFileNames}
+							</Typography>
 						</div>
-					)}
+
+						<div>
+							<Typography variant="h6">タイトル</Typography>
+							<Input
+								value={title}
+								onChange={(e) => setTitle(e.target.value)}
+								placeholder="AI要約/練習問題のタイトルを入力してください（最大100文字）"
+								maxLength={100}
+								className="mt-1 focus:outline-none !border !border-gray-300 focus:!border-gray-900 rounded-lg"
+								labelProps={{
+									className: "before:content-none after:content-none",
+								}}
+								disabled={loading}
+							/>
+						</div>
+
+						<div className="flex gap-4">
+							<Button
+								size="lg"
+								onClick={() => createAiContent("ai-output/stream")}
+								className="flex-1"
+								disabled={loading || !isAnyFileSelected || !title}
+							>
+								AI要約作成
+							</Button>
+							<Button
+								size="lg"
+								onClick={() => createAiContent("ai-exercise/stream")}
+								className="flex-1"
+								disabled={loading || !isAnyFileSelected || !title}
+							>
+								AI練習問題
+							</Button>
+							<Button
+								size="lg"
+								onClick={() => createAiContent("ai-exercise/multiple-choice")}
+								className="flex-1"
+								disabled={loading || !isAnyFileSelected || !title}
+							>
+								選択問題テスト
+							</Button>
+							<Button
+								size="lg"
+								onClick={() => createAiContent("ai-exercise/essay-question")}
+								className="flex-1"
+								disabled={loading || !isAnyFileSelected || !title}
+							>
+								記述問題テスト
+							</Button>
+						</div>
+					</div>
 				</CardBody>
 			</Card>
 		</div>


### PR DESCRIPTION
## Issue No.
#277
resolve #277

## 影響範囲とその理由
ファイル選択画面で最初からタイトルの入力画面や
AI要約やAI練習問題の作成ボタンを表示するように修正

## チェックリスト
<!-- 変更を行った際にチェックした項目にチェックを入れてください。 -->
- [X] 単体テストを実施した
- [ ] 統合テストを実施した
- [ ] ドキュメントを更新した

## スクリーンショット
![スクリーンショット 2025-01-02 10 25 05](https://github.com/user-attachments/assets/af8f962b-3253-4c3e-92e8-34671dd9da70)

## レビュアーに確認してほしいこと 
- フロントエンドのテストが通ること
- ファイル選択画面で最初からタイトルの入力画面やAI要約やAI練習問題の作成ボタンを表示されること

## 関連リンク
<!-- ソースコードに関連するファイルがあればリンクを共有 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI 改善**
	- ファイル選択コンポーネントのユーザーインターフェースを最適化
	- ボタンの有効/無効状態をより明確に制御
	- 選択されたファイルとタイトル入力の表示を一貫して改善

<!-- end of auto-generated comment: release notes by coderabbit.ai -->