### PR TITLE
ファイル選択ページのボタンを修正

### DIFF
--- a/frontend-nextjs/__tests__/features/dashboard/select-files/FileSelectComponent.test.tsx
+++ b/frontend-nextjs/__tests__/features/dashboard/select-files/FileSelectComponent.test.tsx
@@ -102,8 +102,12 @@ describe("FileSelectComponent", () => {
 		);
 		fireEvent.change(titleInput, { target: { value: "テストノート" } });
 
-		// AI要約作成ボタンをクリック
-		const createButton = screen.getByText("要約");
+		// AI要約ボタンをクリック
+		const summaryButton = screen.getByText("要約");
+		fireEvent.click(summaryButton);
+
+		// 作成ボタンをクリック
+		const createButton = screen.getByText("作成");
 		fireEvent.click(createButton);
 
 		// ローカルストレージの確認
@@ -132,7 +136,10 @@ describe("FileSelectComponent", () => {
 		);
 		fireEvent.change(titleInput, { target: { value: "テスト演習" } });
 
-		const createButton = screen.getByText("総合問題");
+		const exerciseButton = screen.getByText("総合問題");
+		fireEvent.click(exerciseButton);
+
+		const createButton = screen.getByText("作成");
 		fireEvent.click(createButton);
 
 		expect(localStorage.getItem("selectedFiles")).toBe('["test1.pdf"]');
@@ -159,7 +166,10 @@ describe("FileSelectComponent", () => {
 		);
 		fireEvent.change(titleInput, { target: { value: "テスト選択問題" } });
 
-		const createButton = screen.getByText("選択問題テスト");
+		const multipleChoiceButton = screen.getByText("選択問題テスト");
+		fireEvent.click(multipleChoiceButton);
+
+		const createButton = screen.getByText("作成");
 		fireEvent.click(createButton);
 
 		expect(localStorage.getItem("selectedFiles")).toBe('["test1.pdf"]');
@@ -171,6 +181,57 @@ describe("FileSelectComponent", () => {
 				"/ai-exercise/multiple-choice",
 			);
 		});
+	});
+
+	it("ファイルを選択して記述問題を作成できること", async () => {
+		render(<FileSelectComponent />);
+
+		await waitFor(() => {
+			expect(screen.getByText("test1.pdf")).toBeInTheDocument();
+		});
+
+		const checkboxes = screen.getAllByRole("checkbox");
+		fireEvent.click(checkboxes[1]);
+
+		const titleInput = screen.getByPlaceholderText(
+			"AI要約/練習問題のタイトルを入力してください（最大100文字）",
+		);
+		fireEvent.change(titleInput, { target: { value: "テスト記述問題" } });
+
+		const essayQuestionButton = screen.getByText("記述問題テスト");
+		fireEvent.click(essayQuestionButton);
+
+		const createButton = screen.getByText("作成");
+		fireEvent.click(createButton);
+
+		expect(localStorage.getItem("selectedFiles")).toBe('["test1.pdf"]');
+		expect(localStorage.getItem("title")).toBe("テスト記述問題");
+		expect(localStorage.getItem("difficulty")).toBe("medium");
+
+		await waitFor(() => {
+			expect(mockRouter.push).toHaveBeenCalledWith(
+				"/ai-exercise/essay-question",
+			);
+		});
+	});
+
+	it("要約を選択したときに問題の難易度がグレーアウトされること", async () => {
+		render(<FileSelectComponent />);
+
+		await waitFor(() => {
+			expect(screen.getByText("test1.pdf")).toBeInTheDocument();
+		});
+
+		const summaryButton = screen.getByText("要約");
+		fireEvent.click(summaryButton);
+
+		const easyRadio = screen.getByLabelText("易しい");
+		const mediumRadio = screen.getByLabelText("普通");
+		const hardRadio = screen.getByLabelText("難しい");
+
+		expect(easyRadio).toBeDisabled();
+		expect(mediumRadio).toBeDisabled();
+		expect(hardRadio).toBeDisabled();
 	});
 
 	it("認証エラー時に適切なエラーメッセージが表示されること", async () => {

--- a/frontend-nextjs/src/features/dashboard/select-files/FileSelectComponent.tsx
+++ b/frontend-nextjs/src/features/dashboard/select-files/FileSelectComponent.tsx
@@ -12,7 +12,9 @@ import {
 	CardBody,
 	CardHeader,
 	Input,
+	Option,
 	Radio,
+	Select,
 	Spinner,
 	Typography,
 } from "@material-tailwind/react";
@@ -61,6 +63,12 @@ export default function FileSelectComponent() {
 	const [error, setError] = useState("");
 	const [success, setSuccess] = useState("");
 	const authFetch = useAuthFetch();
+	const [selectedContentType, setSelectedContentType] = useState<
+		| "ai-output/stream"
+		| "ai-exercise/stream"
+		| "ai-exercise/multiple-choice"
+		| "ai-exercise/essay-question"
+	>("ai-output/stream");
 
 	const handleAuthError = useCallback(
 		async (error: { message: string }) => {
@@ -344,72 +352,102 @@ export default function FileSelectComponent() {
 							/>
 						</div>
 
-						<div className="flex-col gap-4">
-							<Typography variant="h6" className="mt-6">
-								問題の難易度
-							</Typography>
-							<Typography variant="small" className="mb-2">
-								要約作成の場合は適用されません。
-							</Typography>
+						<Typography variant="h6" className="mt-6 mb-2">
+							AI生成物の種類
+						</Typography>
+						<div className="flex justify-stretch gap-4">
+							<Button
+								variant={
+									selectedContentType === "ai-output/stream"
+										? "filled"
+										: "outlined"
+								}
+								onClick={() => setSelectedContentType("ai-output/stream")}
+								className="flex-1"
+								disabled={loading}
+							>
+								要約
+							</Button>
+							<Button
+								variant={
+									selectedContentType === "ai-exercise/stream"
+										? "filled"
+										: "outlined"
+								}
+								onClick={() => setSelectedContentType("ai-exercise/stream")}
+								className="flex-1"
+								disabled={loading}
+							>
+								総合問題
+							</Button>
+							<Button
+								variant={
+									selectedContentType === "ai-exercise/multiple-choice"
+										? "filled"
+										: "outlined"
+								}
+								onClick={() =>
+									setSelectedContentType("ai-exercise/multiple-choice")
+								}
+								className="flex-1"
+								disabled={loading}
+							>
+								選択問題テスト
+							</Button>
+							<Button
+								variant={
+									selectedContentType === "ai-exercise/essay-question"
+										? "filled"
+										: "outlined"
+								}
+								onClick={() =>
+									setSelectedContentType("ai-exercise/essay-question")
+								}
+								className="flex-1"
+								disabled={loading}
+							>
+								記述問題テスト
+							</Button>
+						</div>
 
-							<div className="flex gap-4 justify-stretch">
-								<Radio
-									name="type"
-									label="易しい"
-									onChange={() => setDifficulty("easy")}
-									checked={difficulty === "easy"}
-								/>
-								<Radio
-									name="type"
-									label="普通"
-									onChange={() => setDifficulty("medium")}
-									checked={difficulty === "medium"}
-									defaultChecked
-								/>
-								<Radio
-									name="type"
-									label="難しい"
-									onChange={() => setDifficulty("hard")}
-									checked={difficulty === "hard"}
-								/>
-							</div>
-							<Typography variant="h6" className="mt-6 mb-2">
-								AI生成物の種類
-							</Typography>
-							<div className="flex justify-stretch gap-4">
-								<Button
-									size="lg"
-									onClick={() => createAiContent("ai-output/stream")}
-									className="flex-1"
-									disabled={loading || !isAnyFileSelected || !title}
-								>
-									要約
-								</Button>
-								<Button
-									size="lg"
-									onClick={() => createAiContent("ai-exercise/stream")}
-									className="flex-1"
-									disabled={loading || !isAnyFileSelected || !title}
-								>
-									総合問題
-								</Button>
-								<Button
-									size="lg"
-									onClick={() => createAiContent("ai-exercise/multiple-choice")}
-									className="flex-1"
-									disabled={loading || !isAnyFileSelected || !title}
-								>
-									選択問題テスト
-								</Button>
-								<Button
-									size="lg"
-									onClick={() => createAiContent("ai-exercise/essay-question")}
-									className="flex-1"
-									disabled={loading || !isAnyFileSelected || !title}
-								>
-									記述問題テスト
-								</Button>
-							</div>
+						<Typography variant="h6" className="mt-6">
+							問題の難易度
+						</Typography>
+
+						<div className="flex gap-4 justify-stretch">
+							<Radio
+								name="type"
+								label="易しい"
+								onChange={() => setDifficulty("easy")}
+								checked={difficulty === "easy"}
+								disabled={selectedContentType === "ai-output/stream"}
+							/>
+							<Radio
+								name="type"
+								label="普通"
+								onChange={() => setDifficulty("medium")}
+								checked={difficulty === "medium"}
+								defaultChecked
+								disabled={selectedContentType === "ai-output/stream"}
+							/>
+							<Radio
+								name="type"
+								label="難しい"
+								onChange={() => setDifficulty("hard")}
+								checked={difficulty === "hard"}
+								disabled={selectedContentType === "ai-output/stream"}
+							/>
+						</div>
+
+						<div className="flex justify-stretch gap-4 mt-4">
+							<Button
+								size="lg"
+								onClick={() => createAiContent(selectedContentType)}
+								className="flex-1"
+								disabled={loading || !isAnyFileSelected || !title}
+							>
+								作成
+							</Button>
 						</div>
 					</div>
 				</CardBody>


### PR DESCRIPTION
## Issue No.
#270

## 影響範囲とその理由
要約スタイルの追加にあたりその前段階の作業として
事前に「要約」、「総合問題」、「選択問題テスト」、「記述問題テスト」を選んでから
最後に作成ボタンを押して、各ページに遷移するように修正した

## チェックリスト
<!-- 変更を行った際にチェックした項目にチェックを入れてください。 -->
- [X] 単体テストを実施した
- [ ] 統合テストを実施した
- [ ] ドキュメントを更新した

## スクリーンショット
![スクリーンショット 2025-01-15 20 19 17](https://github.com/user-attachments/assets/b2c0daad-8845-4aea-9597-3d91c14f9482)

## レビュアーに確認してほしいこと 
- フロントエンドのテストが通ること
- 「要約」、「総合問題」、「選択問題テスト」、「記述問題テスト」が正常に作成できること

## 関連リンク
<!-- ソースコードに関連するファイルがあればリンクを共有 -->
