### PR TITLE
ファイル選択ページのテーブルを更新日時の降順に変更

### DIFF
--- a/backend/app/schemas/files.py
+++ b/backend/app/schemas/files.py
@@ -35,8 +35,8 @@ class FileCreate(FileBase):
 class FileUpdate(FileBase):
     """
     FileBaseクラスを継承したファイル更新を表すクラス。
-    :param created_at: 作成日時
-    :type created_at: datetime
+    :param updated_at: 更新日時
+    :type updated_at: datetime
     """
 
     user_id: str
@@ -53,6 +53,8 @@ class File(FileBase):
     :type user_id: str
     :param created_at: 作成日時
     :type created_at: datetime
+    :param updated_at: 更新日時
+    :type updated_at: datetime
     :param model_config: モデルの設定辞書
     :type model_config: ConfigDict
     """
@@ -60,5 +62,6 @@ class File(FileBase):
     id: int
     user_id: str
     created_at: datetime
+    updated_at: datetime
 
     model_config = ConfigDict(from_attributes=True)

--- a/frontend-nextjs/__tests__/features/dashboard/select-files/FileTableComponent.test.tsx
+++ b/frontend-nextjs/__tests__/features/dashboard/select-files/FileTableComponent.test.tsx
@@ -60,19 +60,22 @@ const mockFiles = [
 		file_name: "test1.pdf",
 		file_size: "1.5 MB",
 		created_at: "2024-03-15T10:00:00",
+		updated_at: "2024-03-15T11:00:00",
 		select: false,
 	},
 	{
 		file_name: "sample2.jpg",
 		file_size: "500 KB",
 		created_at: "2024-03-14T15:30:00",
+		updated_at: "2024-03-14T16:30:00",
 		select: false,
 	},
 	{
 		file_name: "document3.docx",
 		file_size: "2.2 MB",
 		created_at: "2024-03-16T09:15:00",
-		select: true,
+		updated_at: "2024-03-16T10:15:00",
+		select: false,
 	},
 ];
 
@@ -115,6 +118,9 @@ describe("FileTable", () => {
 		expect(
 			screen.getByRole("columnheader", { name: /作成日時/ }),
 		).toBeInTheDocument();
+		expect(
+			screen.getByRole("columnheader", { name: /更新日時/ }),
+		).toBeInTheDocument();
 	});
 
 	it("ファイル一覧が正しく表示されること", () => {
@@ -138,27 +144,32 @@ describe("FileTable", () => {
 		const fileNameHeader = screen.getByRole("columnheader", {
 			name: /ファイル名/,
 		});
-		fireEvent.click(fileNameHeader);
 
-		const cells = screen.getAllByRole("cell");
-		const fileNameCells = cells.filter((cell) =>
-			cell.textContent?.match(/\.(pdf|jpg|docx)$/),
-		);
-
-		// 昇順確認（文字列の自然な順序）
-		expect(fileNameCells[0]).toHaveTextContent("test1.pdf");
-		expect(fileNameCells[1]).toHaveTextContent("sample2.jpg");
-		expect(fileNameCells[2]).toHaveTextContent("document3.docx");
-
-		// もう一度クリックで降順に
-		fireEvent.click(fileNameHeader);
-		const sortedCells = screen
+		// 初期状態を確認 (更新日時でのデフォルトソート、降順)
+		const initialCells = screen
 			.getAllByRole("cell")
 			.filter((cell) => cell.textContent?.match(/\.(pdf|jpg|docx)$/));
+		expect(initialCells[0]).toHaveTextContent("document3.docx");
+		expect(initialCells[1]).toHaveTextContent("test1.pdf");
+		expect(initialCells[2]).toHaveTextContent("sample2.jpg");
 
-		expect(sortedCells[0]).toHaveTextContent("document3.docx");
-		expect(sortedCells[1]).toHaveTextContent("sample2.jpg");
-		expect(sortedCells[2]).toHaveTextContent("test1.pdf");
+		// ファイル名でソート（昇順）
+		fireEvent.click(fileNameHeader);
+		const ascendingCells = screen
+			.getAllByRole("cell")
+			.filter((cell) => cell.textContent?.match(/\.(pdf|jpg|docx)$/));
+		expect(ascendingCells[0]).toHaveTextContent("document3.docx");
+		expect(ascendingCells[1]).toHaveTextContent("sample2.jpg");
+		expect(ascendingCells[2]).toHaveTextContent("test1.pdf");
+
+		// ファイル名でソート（降順）
+		fireEvent.click(fileNameHeader);
+		const descendingCells = screen
+			.getAllByRole("cell")
+			.filter((cell) => cell.textContent?.match(/\.(pdf|jpg|docx)$/));
+		expect(descendingCells[0]).toHaveTextContent("test1.pdf");
+		expect(descendingCells[1]).toHaveTextContent("sample2.jpg");
+		expect(descendingCells[2]).toHaveTextContent("document3.docx");
 	});
 
 	it("全選択チェックボックスが正しく動作すること", () => {
@@ -170,9 +181,10 @@ describe("FileTable", () => {
 
 	it("個別のチェックボックスが正しく動作すること", () => {
 		renderWithProviders(<FileTable {...defaultProps} />);
-		const firstFileCheckbox = screen.getAllByRole("checkbox")[1];
-		fireEvent.click(firstFileCheckbox);
-		expect(mockHandleSelect).toHaveBeenCalledWith("document3.docx", false);
+		const fileCheckboxes = screen.getAllByRole("checkbox");
+		// 最初のファイルのチェックボックス
+		fireEvent.click(fileCheckboxes[1]);
+		expect(mockHandleSelect).toHaveBeenCalledWith("document3.docx", true);
 	});
 
 	it("ローディング状態でチェックボックスが無効化されること", () => {
@@ -190,11 +202,16 @@ describe("FileTable", () => {
 		expect(screen.getByText("2.20 MB")).toBeInTheDocument();
 	});
 
-	it("作成日時が正しくフォーマットされること", () => {
+	it("作成日時と更新日時が正しくフォーマットされること", () => {
 		renderWithProviders(<FileTable {...defaultProps} />);
+		// 作成日時のチェック
 		expect(mockFormatDate).toHaveBeenCalledWith("2024-03-15T10:00:00");
 		expect(mockFormatDate).toHaveBeenCalledWith("2024-03-14T15:30:00");
 		expect(mockFormatDate).toHaveBeenCalledWith("2024-03-16T09:15:00");
+		// 更新日時のチェック
+		expect(mockFormatDate).toHaveBeenCalledWith("2024-03-15T11:00:00");
+		expect(mockFormatDate).toHaveBeenCalledWith("2024-03-14T16:30:00");
+		expect(mockFormatDate).toHaveBeenCalledWith("2024-03-16T10:15:00");
 	});
 
 	it("サイズでソートが正しく動作すること", () => {
@@ -216,10 +233,23 @@ describe("FileTable", () => {
 		const dateHeader = screen.getByRole("columnheader", { name: /作成日時/ });
 		fireEvent.click(dateHeader);
 
+		// 日付の昇順でソートされることを確認
 		const calls = mockFormatDate.mock.calls.map((call) => call[0]);
 		expect(calls).toContain("2024-03-14T15:30:00");
 		expect(calls).toContain("2024-03-15T10:00:00");
 		expect(calls).toContain("2024-03-16T09:15:00");
+	});
+
+	it("更新日時でソートが正しく動作すること", () => {
+		renderWithProviders(<FileTable {...defaultProps} />);
+		const dateHeader = screen.getByRole("columnheader", { name: /更新日時/ });
+		fireEvent.click(dateHeader);
+
+		// 更新日時の昇順でソートされることを確認
+		const calls = mockFormatDate.mock.calls.map((call) => call[0]);
+		expect(calls).toContain("2024-03-14T16:30:00");
+		expect(calls).toContain("2024-03-15T11:00:00");
+		expect(calls).toContain("2024-03-16T10:15:00");
 	});
 
 	it("無効なファイルサイズを処理できること", () => {
@@ -228,6 +258,7 @@ describe("FileTable", () => {
 				file_name: "invalid.txt",
 				file_size: "invalid",
 				created_at: "2024-03-15T10:00:00",
+				updated_at: "2024-03-15T11:00:00",
 				select: false,
 			},
 			...mockFiles,

--- a/frontend-nextjs/src/features/dashboard/select-files/FileTableComponent.tsx
+++ b/frontend-nextjs/src/features/dashboard/select-files/FileTableComponent.tsx
@@ -14,6 +14,7 @@ interface FileData {
 	file_name: string;
 	file_size: string | number;
 	created_at: string;
+	updated_at: string;
 	select?: boolean;
 	id?: string;
 	user_id?: string;
@@ -28,7 +29,7 @@ interface FileTableProps {
 	formatDate: (dateStr: string) => string;
 }
 
-type SortKey = "file_name" | "file_size" | "created_at";
+type SortKey = "file_name" | "file_size" | "created_at" | "updated_at";
 type SortDirection = "asc" | "desc";
 
 const FileTable: React.FC<FileTableProps> = ({
@@ -39,8 +40,8 @@ const FileTable: React.FC<FileTableProps> = ({
 	areAllFilesSelected,
 	formatDate,
 }) => {
-	const [sortKey, setSortKey] = useState<SortKey>("file_name");
-	const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
+	const [sortKey, setSortKey] = useState<SortKey>("updated_at");
+	const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
 	const [searchQuery, setSearchQuery] = useState("");
 	const [selectedFile, setSelectedFile] = useState<string | null>(null);
 	const { previewUrls, generatePreviewUrl } = useFilePreview();
@@ -113,7 +114,7 @@ const FileTable: React.FC<FileTableProps> = ({
 				const aBytes = getFileSizeInBytes(a[sortKey]);
 				const bBytes = getFileSizeInBytes(b[sortKey]);
 				compareValue = aBytes - bBytes;
-			} else if (sortKey === "created_at") {
+			} else if (sortKey === "created_at" || sortKey === "updated_at") {
 				compareValue =
 					new Date(a[sortKey]).getTime() - new Date(b[sortKey]).getTime();
 			} else {
@@ -142,88 +143,136 @@ const FileTable: React.FC<FileTableProps> = ({
 					className="w-full max-w-xs px-4 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-800 focus:border-transparent"
 				/>
 			</div>
-			<table className="w-full min-w-max table-auto text-left">
-				<thead>
-					<tr>
-						<th className="border-b p-4">
-							<Checkbox
-								checked={areAllFilesSelected}
-								onChange={(e) => handleSelectAll(e.target.checked)}
-								disabled={loading}
-							/>
-						</th>
-						<th
-							className="border-b p-4 cursor-pointer"
-							onClick={() => handleSort("file_name")}
-							onKeyUp={(e) => e.key === "Enter" && handleSort("file_name")}
-						>
-							<Typography variant="small" className="font-normal leading-none">
-								ファイル名 {getSortIcon("file_name")}
-							</Typography>
-						</th>
-						<th
-							className="border-b p-4 cursor-pointer"
-							onClick={() => handleSort("file_size")}
-							onKeyUp={(e) => e.key === "Enter" && handleSort("file_size")}
-						>
-							<Typography variant="small" className="font-normal leading-none">
-								サイズ {getSortIcon("file_size")}
-							</Typography>
-						</th>
-						<th
-							className="border-b p-4 cursor-pointer"
-							onClick={() => handleSort("created_at")}
-							onKeyUp={(e) => e.key === "Enter" && handleSort("created_at")}
-						>
-							<Typography variant="small" className="font-normal leading-none">
-								作成日時 {getSortIcon("created_at")}
-							</Typography>
-						</th>
-						<th className="border-b p-4">
-							<Typography variant="small" className="font-normal leading-none">
-								プレビュー
-							</Typography>
-						</th>
-					</tr>
-				</thead>
-				<tbody>
-					{getSortedFiles().map((file) => (
-						<tr key={file.file_name}>
-							<td className="p-4">
-								<Checkbox
-									checked={file.select}
-									onChange={(e) =>
-										handleSelect(file.file_name, e.target.checked)
-									}
-									disabled={loading}
-								/>
-							</td>
-							<td className="p-4">
-								<Typography variant="small">{file.file_name}</Typography>
-							</td>
-							<td className="p-4">
-								<Typography variant="small">
-									{formatFileSize(getFileSizeInBytes(file.file_size))}
-								</Typography>
-							</td>
-							<td className="p-4">
-								<Typography variant="small">
-									{formatDate(file.created_at)}
-								</Typography>
-							</td>
-							<td className="p-4">
-								<IconButton
-									variant="text"
-									color="blue-gray"
-									onClick={() => handlePreview(file.file_name)}
-								>
-									<EyeIcon className="h-4 w-4" />
-								</IconButton>
-							</td>
-						</tr>
-					))}
-				</tbody>
-			</table>
+			<div className="overflow-x-auto">
+				<div className="inline-block min-w-full align-middle">
+					<div className="overflow-hidden">
+						<table className="min-w-full divide-y divide-gray-200">
+							<thead>
+								<tr>
+									<th className="border-b p-4">
+										<Checkbox
+											checked={areAllFilesSelected}
+											onChange={(e) => handleSelectAll(e.target.checked)}
+											disabled={loading}
+										/>
+									</th>
+									<th
+										className="border-b p-4 cursor-pointer"
+										onClick={() => handleSort("file_name")}
+										onKeyUp={(e) =>
+											e.key === "Enter" && handleSort("file_name")
+										}
+									>
+										<Typography
+											variant="small"
+											className="font-normal leading-none"
+										>
+											ファイル名 {getSortIcon("file_name")}
+										</Typography>
+									</th>
+									<th
+										className="border-b p-4 cursor-pointer hidden sm:table-cell"
+										onClick={() => handleSort("file_size")}
+										onKeyUp={(e) =>
+											e.key === "Enter" && handleSort("file_size")
+										}
+									>
+										<Typography
+											variant="small"
+											className="font-normal leading-none"
+										>
+											サイズ {getSortIcon("file_size")}
+										</Typography>
+									</th>
+									<th
+										className="border-b p-4 cursor-pointer hidden md:table-cell"
+										onClick={() => handleSort("created_at")}
+										onKeyUp={(e) =>
+											e.key === "Enter" && handleSort("created_at")
+										}
+									>
+										<Typography
+											variant="small"
+											className="font-normal leading-none"
+										>
+											作成日時 {getSortIcon("created_at")}
+										</Typography>
+									</th>
+									<th
+										className="border-b p-4 cursor-pointer hidden md:table-cell"
+										onClick={() => handleSort("updated_at")}
+										onKeyUp={(e) =>
+											e.key === "Enter" && handleSort("updated_at")
+										}
+									>
+										<Typography
+											variant="small"
+											className="font-normal leading-none"
+										>
+											更新日時 {getSortIcon("updated_at")}
+										</Typography>
+									</th>
+									<th className="border-b p-4">
+										<Typography
+											variant="small"
+											className="font-normal leading-none"
+										>
+											プレビュー
+										</Typography>
+									</th>
+								</tr>
+							</thead>
+							<tbody className="divide-y divide-gray-200">
+								{getSortedFiles().map((file) => (
+									<tr key={file.file_name}>
+										<td className="p-4">
+											<Checkbox
+												checked={file.select}
+												onChange={(e) =>
+													handleSelect(file.file_name, e.target.checked)
+												}
+												disabled={loading}
+											/>
+										</td>
+										<td className="p-4 max-w-xs">
+											<Typography
+												variant="small"
+												className="whitespace-normal break-words"
+											>
+												{file.file_name}
+											</Typography>
+										</td>
+										<td className="p-4 hidden sm:table-cell">
+											<Typography variant="small">
+												{formatFileSize(getFileSizeInBytes(file.file_size))}
+											</Typography>
+										</td>
+										<td className="p-4 hidden md:table-cell">
+											<Typography variant="small">
+												{formatDate(file.created_at)}
+											</Typography>
+										</td>
+										<td className="p-4 hidden md:table-cell">
+											<Typography variant="small">
+												{formatDate(file.updated_at)}
+											</Typography>
+										</td>
+										<td className="p-4">
+											<IconButton
+												variant="text"
+												color="blue-gray"
+												onClick={() => handlePreview(file.file_name)}
+											>
+												<EyeIcon className="h-4 w-4" />
+											</IconButton>
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</div>
 
 			{selectedFile && previewUrls[selectedFile] && (
 				<FilePreviewComponent


### PR DESCRIPTION
## Issue No.
<!-- 対応しているissue番号を貼る。 -->
<!-- resolve <issue番号>としてください (resolveは残す) -->

resolve #303 

## 影響範囲とその理由
<!-- この変更により起こり得る影響範囲とその理由を書いてください。 -->
ファイル選択ページのリストが更新日時の新しいファイルが一番上に来るように変更されます。

## チェックリスト
<!-- 変更を行った際にチェックした項目にチェックを入れてください。 -->
- [x] 単体テストを実施した
- [ ] 統合テストを実施した
- [ ] ドキュメントを更新した

## スクリーンショット
<!-- UIの変更がある場合は、Before / Afterのスクリーンショットや動作が分かるGIFなどを添付してください。 -->
<img width="1448" alt="スクリーンショット 2025-01-17 23 48 37" src="https://github.com/user-attachments/assets/3a37d2c8-b681-434e-a322-491840aa950e" />


## レビュアーに確認してほしいこと 
<!-- テストや事象の再現が必要な場合、レビュアーが再現できる実施手順を必ず明記してください！ -->
<!-- レビュワーに特に注目してほしいポイントや、不安な部分があれば明記してください。 -->
◎ファイル選択ページで更新日時が新しいファイルが上に来ることを確認して欲しいです。よろしくお願いします🙇

## 関連リンク
<!-- ソースコードに関連するファイルがあればリンクを共有 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ファイルテーブルに更新日時（`updated_at`）の追跡と表示を追加
	- ファイルリストのデフォルトソートを更新日時の降順に変更

- **改善点**
	- ファイルテーブルのレスポンシブデザインを強化
	- 画面サイズに応じた列の表示/非表示を実装
	- ファイル名の表示方法を改善

- **バグ修正**
	- ソート機能を更新日時に対応するよう修正

<!-- end of auto-generated comment: release notes by coderabbit.ai -->