### PR TITLE
要約スタイルを追加

### DIFF
--- a/backend/app/routers/outputs_stream.py
+++ b/backend/app/routers/outputs_stream.py
@@ -93,7 +93,7 @@ async def request_content(
 
     try:
         # ファイル名のリストを元に、コンテンツを生成
-        response = generate_content_stream(request.files, uid)
+        response = generate_content_stream(request.files, uid, request.style)
     except NotFound as e:
         logging.error(f"File not found in Google Cloud Storage: {e}")
         raise HTTPException(

--- a/backend/app/schemas/outputs.py
+++ b/backend/app/schemas/outputs.py
@@ -75,3 +75,4 @@ class OutputRead(OutputBase):
 class OutputRequest(BaseModel):
     files: list[str]
     title: str
+    style: str

--- a/backend/tests/test_gemini_request_stream.py
+++ b/backend/tests/test_gemini_request_stream.py
@@ -73,7 +73,7 @@ async def test_generate_content_stream_success(
     )
 
     # テスト対象関数の実行(pdfファイル、pngファイルを指定)
-    result = generate_content_stream(["file1.pdf", "file2.png"], "test_user")
+    result = generate_content_stream(["file1.pdf", "file2.png"], "test_user", "casual")
 
     accumulated_content = []
     async for content in result:
@@ -109,7 +109,7 @@ async def test_generate_content_stream_not_found(
 
     # テスト対象関数の実行とエラーハンドリングの確認
     with pytest.raises(NotFound) as excinfo:
-        result = generate_content_stream(["non_existent_file.pdf"], "test_user")
+        result = generate_content_stream(["non_existent_file.pdf"], "test_user", "casual")
         async for _ in result:
             pass
     expected_error_message = "File test_user/non_existent_file.pdf does not exist in the bucket"
@@ -141,7 +141,7 @@ async def test_generate_content_stream_invalid_argument(
 
     # テスト対象関数の実行とエラーハンドリングの確認
     with pytest.raises(InvalidArgument) as excinfo:
-        result = generate_content_stream(["invalid_file.txt"], "test_user")
+        result = generate_content_stream(["invalid_file.txt"], "test_user", "casual")
         async for _ in result:
             pass
     assert "Invalid file format" in str(excinfo.value)
@@ -172,7 +172,7 @@ async def test_generate_content_stream_google_api_error(
 
     # テスト対象関数の実行とエラーハンドリングの確認
     with pytest.raises(GoogleAPIError) as excinfo:
-        result = generate_content_stream(["file1.pdf"], "test_user")
+        result = generate_content_stream(["file1.pdf"], "test_user", "casual")
         async for _ in result:
             pass
     assert "Google API error" in str(excinfo.value)
@@ -201,7 +201,7 @@ async def test_generate_content_stream_unexpected_error(
 
     # テスト対象関数の実行とエラーハンドリングの確認
     with pytest.raises(Exception) as excinfo:
-        result = generate_content_stream(["file1.pdf"], "test_user")
+        result = generate_content_stream(["file1.pdf"], "test_user", "casual")
         async for _ in result:
             pass
     assert "Unexpected error" in str(excinfo.value)
@@ -232,7 +232,7 @@ async def test_generate_content_stream_attribute_error(
 
     # テスト対象関数の実行とエラーハンドリングの確認
     with pytest.raises(AttributeError) as excinfo:
-        result = generate_content_stream(["file1.pdf", "file2.png"], "test_user")
+        result = generate_content_stream(["file1.pdf", "file2.png"], "test_user", "casual")
         async for _ in result:
             pass
     assert "Model attribute error" in str(excinfo.value)
@@ -263,7 +263,7 @@ async def test_generate_content_stream_type_error(
 
     # テスト対象関数の実行とエラーハンドリングの確認
     with pytest.raises(TypeError) as excinfo:
-        result = generate_content_stream(["file1.pdf", "file2.png"], "test_user")
+        result = generate_content_stream(["file1.pdf", "file2.png"], "test_user", "casual")
         async for _ in result:
             pass
     assert "Type error in model generation" in str(excinfo.value)

--- a/backend/tests/test_routers_outputs_stream.py
+++ b/backend/tests/test_routers_outputs_stream.py
@@ -58,10 +58,10 @@ async def test_request_content_stream_success(
     mock_get_file_id.return_value = file_data.id
 
     # モックストリームを返すようにパッチ
-    async def mock_streamer(file_names: list[str]) -> AsyncGenerator[str, None]:
+    async def mock_streamer(file_names: list[str], style: str) -> AsyncGenerator[str, None]:
         yield "生成されたコンテンツ"
 
-    mock_generate_content_stream.return_value = mock_streamer(["file1.pdf"])
+    mock_generate_content_stream.return_value = mock_streamer(["file1.pdf"], "casual")
 
 
 # ファイルが見つからない場合のテスト
@@ -76,14 +76,14 @@ async def test_request_content_stream_file_not_found(mock_get_file_id: Mock) -> 
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         response = await ac.post(
             "/outputs/request_stream",
-            json={"files": ["file1.pdf"], "title": "ファイル分析課題"},
+            json={"files": ["file1.pdf"], "title": "ファイル分析課題", "style": "casual"},
             headers=headers,
         )
     assert response.status_code == 404
     assert "指定されたファイルの一部がデータベースに存在しません" in response.text
 
 
-# Google Cloud Storageでファイルが見つからない場合のテスト
+# Google Cloud Storageでファイルが見つからない場���のテスト
 @pytest.mark.asyncio
 @patch("app.routers.outputs_stream.get_file_id_by_name_and_userid")
 @patch("app.routers.outputs_stream.generate_content_stream")
@@ -114,7 +114,7 @@ async def test_request_content_stream_gcs_not_found(
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         response = await ac.post(
             "/outputs/request_stream",
-            json={"files": ["file111111.pdf"], "title": "ファイル分析課題"},
+            json={"files": ["file111111.pdf"], "title": "ファイル分析課題", "style": "casual"},
             headers=headers,
         )
 
@@ -153,7 +153,7 @@ async def test_request_content_stream_invalid_filename(
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         response = await ac.post(
             "/outputs/request_stream",
-            json={"files": ["invalid/file/name.pdf"], "title": "テスト"},
+            json={"files": ["invalid/file/name.pdf"], "title": "テスト", "style": "casual"},
             headers=headers,
         )
 
@@ -192,7 +192,7 @@ async def test_request_content_stream_google_api_error(
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         response = await ac.post(
             "/outputs/request_stream",
-            json={"files": ["file1.pdf"], "title": "タイトル"},
+            json={"files": ["file1.pdf"], "title": "タイトル", "style": "casual"},
             headers=headers,
         )
 
@@ -217,7 +217,7 @@ async def test_request_content_stream_file_id_error(
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         response = await ac.post(
             "/outputs/request_stream",
-            json={"files": ["file1.pdf"], "title": "タイトル"},
+            json={"files": ["file1.pdf"], "title": "タイトル", "style": "casual"},
             headers=headers,
         )
 

--- a/frontend-nextjs/__tests__/features/dashboard/ai-output/stream/hooks/useOutputGenerator.test.ts
+++ b/frontend-nextjs/__tests__/features/dashboard/ai-output/stream/hooks/useOutputGenerator.test.ts
@@ -1,3 +1,4 @@
+import { styleText } from "node:util";
 import { useOutputGenerator } from "@/features/dashboard/ai-output/stream/hooks/useOutputGenerator";
 import * as useAuthFetchModule from "@/hooks/useAuthFetch";
 import { renderHook, waitFor } from "@testing-library/react";
@@ -35,6 +36,7 @@ describe("useOutputGenerator", () => {
 	const mockLocalStorageData = {
 		selectedFiles: JSON.stringify(["file1.pdf", "file2.pdf"]),
 		title: "テストタイトル",
+		style: "casual",
 	};
 
 	beforeEach(() => {
@@ -87,6 +89,7 @@ describe("useOutputGenerator", () => {
 				body: JSON.stringify({
 					files: ["file1.pdf", "file2.pdf"],
 					title: "テストタイトル",
+					style: "casual",
 				}),
 			},
 		);

--- a/frontend-nextjs/src/features/dashboard/ai-output/stream/hooks/useOutputGenerator.ts
+++ b/frontend-nextjs/src/features/dashboard/ai-output/stream/hooks/useOutputGenerator.ts
@@ -37,6 +37,7 @@ export function useOutputGenerator() {
 				localStorage.getItem("selectedFiles") || "[]",
 			);
 			const title = localStorage.getItem("title");
+			const style = localStorage.getItem("style");
 
 			if (!selectedFiles || !title) {
 				throw new Error("必要な情報が見つかりません");
@@ -53,6 +54,7 @@ export function useOutputGenerator() {
 					body: JSON.stringify({
 						files: selectedFiles,
 						title: title,
+						style: style,
 					}),
 				},
 			);

--- a/frontend-nextjs/src/features/dashboard/select-files/FileSelectComponent.tsx
+++ b/frontend-nextjs/src/features/dashboard/select-files/FileSelectComponent.tsx
@@ -28,6 +28,7 @@ interface FileData {
 	file_name: string;
 	file_size: string;
 	created_at: string;
+	updated_at: string;
 	select?: boolean;
 	id?: string;
 	user_id?: string;
@@ -59,6 +60,7 @@ export default function FileSelectComponent() {
 	const [files, setFiles] = useState<FileData[]>([]);
 	const [title, setTitle] = useState("");
 	const [difficulty, setDifficulty] = useState("medium");
+	const [style, setStyle] = useState("casual");
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState("");
 	const [success, setSuccess] = useState("");
@@ -176,12 +178,13 @@ export default function FileSelectComponent() {
 				localStorage.setItem("title", title);
 				localStorage.setItem("uid", user.uid);
 				localStorage.setItem("difficulty", difficulty);
+				localStorage.setItem("style", style);
 				router.push(`/${type}`);
 			} catch (err) {
 				setError("データの保存に失敗しました。もう一度お試しください。");
 			}
 		},
-		[files, title, difficulty, router, user],
+		[files, title, difficulty, router, user, style],
 	);
 
 	const resetAll = useCallback(() => {
@@ -408,6 +411,35 @@ export default function FileSelectComponent() {
 							>
 								記述問題テスト
 							</Button>
+						</div>
+
+						<Typography variant="h6" className="mt-6">
+							要約のスタイル
+						</Typography>
+						<div className="flex gap-4 justify-stretch">
+							<Radio
+								name="style"
+								label="カジュアル"
+								onChange={() => setStyle("casual")}
+								checked={style === "casual"}
+								defaultChecked
+								disabled={
+									selectedContentType === "ai-exercise/stream" ||
+									selectedContentType === "ai-exercise/multiple-choice" ||
+									selectedContentType === "ai-exercise/essay-question"
+								}
+							/>
+							<Radio
+								name="style"
+								label="シンプル"
+								onChange={() => setStyle("simple")}
+								checked={style === "simple"}
+								disabled={
+									selectedContentType === "ai-exercise/stream" ||
+									selectedContentType === "ai-exercise/multiple-choice" ||
+									selectedContentType === "ai-exercise/essay-question"
+								}
+							/>
 						</div>
 
 						<Typography variant="h6" className="mt-6">


### PR DESCRIPTION
## Issue No.
#270
#271

## 影響範囲とその理由
<!-- この変更により起こり得る影響範囲とその理由を書いてください。 -->

## チェックリスト
<!-- 変更を行った際にチェックした項目にチェックを入れてください。 -->
- [X] 単体テストを実施した
- [ ] 統合テストを実施した
- [ ] ドキュメントを更新した

## スクリーンショット
![スクリーンショット 2025-01-18 17 50 42](https://github.com/user-attachments/assets/af37d4b0-0c06-40bd-b959-72398939ae2c)

## レビュアーに確認してほしいこと 
- 要約スタイルが追加されて、スタイルに応じた要約が出力されること
- フロントエンドのテストが通ること
- バックエンドのテストが通ること

## 関連リンク
<!-- ソースコードに関連するファイルがあればリンクを共有 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- AIコンテンツ生成に「カジュアル」と「シンプル」の2つのスタイルを追加
	- ファイル選択画面でコンテンツのスタイルを選択可能に

- **機能改善**
	- ユーザーが要約のスタイルを選択できるUIを実装
	- ローカルストレージにスタイル設定を保存

- **対応プラットフォーム**
	- フロントエンド（Next.js）
	- バックエンドAPI

<!-- end of auto-generated comment: release notes by coderabbit.ai -->