### PR TITLE
レスポンシブなテーブル表示に修正

### DIFF
--- a/frontend-nextjs/__tests__/features/dashboard/ai-output/select-ai-output/OutputTable.test.tsx
+++ b/frontend-nextjs/__tests__/features/dashboard/ai-output/select-ai-output/OutputTable.test.tsx
@@ -1,0 +1,247 @@
+import OutputTable from "@/features/dashboard/ai-output/select-ai-output/OutputTable";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// @material-tailwind/react コンポーネントのモック
+vi.mock("@material-tailwind/react", () => ({
+	Radio: ({
+		checked,
+		onChange,
+	}: {
+		checked: boolean;
+		onChange: () => void;
+	}) => (
+		<input
+			type="radio"
+			checked={checked}
+			onChange={onChange}
+			data-testid="radio"
+		/>
+	),
+	Typography: ({ children }: { children: React.ReactNode }) => (
+		<span>{children}</span>
+	),
+}));
+
+describe("OutputTable コンポーネント", () => {
+	// テスト用の出力データ
+	const mockOutputs = [
+		{
+			id: 1,
+			title: "First Output",
+			output: "This is the first output.",
+			user_id: "user1",
+			created_at: "2023-10-01T10:00:00Z",
+			files: [
+				{
+					id: "f1",
+					file_name: "file1.txt",
+					file_size: "2KB",
+					created_at: "2023-10-01",
+					user_id: "user1",
+				},
+			],
+			style: "Style1",
+		},
+		{
+			id: 2,
+			title: "Second Output",
+			output: "This is the second output.",
+			user_id: "user2",
+			created_at: "2023-10-02T12:00:00Z",
+			files: [
+				{
+					id: "f2",
+					file_name: "file2.txt",
+					file_size: "3KB",
+					created_at: "2023-10-02",
+					user_id: "user2",
+				},
+				{
+					id: "f3",
+					file_name: "file3.txt",
+					file_size: "1KB",
+					created_at: "2023-10-02",
+					user_id: "user2",
+				},
+			],
+			style: "Style2",
+		},
+	];
+
+	// モック関数の定義
+	const mockHandleSelect = vi.fn();
+	const mockGetSortIcon = vi.fn().mockReturnValue("🔽");
+	const mockHandleSort = vi.fn();
+	const mockHandleOpenModal = vi.fn();
+	const mockFormatStyle = vi
+		.fn()
+		.mockImplementation((style: string | null) => `Formatted ${style}`);
+	const mockFormatDate = vi
+		.fn()
+		.mockImplementation((dateStr: string) =>
+			new Date(dateStr).toLocaleString(),
+		);
+	const mockTruncateResponse = vi
+		.fn()
+		.mockImplementation((str: string) => `${str.slice(0, 10)}...`);
+
+	// コンポーネントをレンダリングするヘルパー関数
+	const renderComponent = (selectedOutputId: number | null = null) => {
+		render(
+			<OutputTable
+				outputs={mockOutputs}
+				selectedOutputId={selectedOutputId}
+				handleSelect={mockHandleSelect}
+				getSortIcon={mockGetSortIcon}
+				handleSort={mockHandleSort}
+				handleOpenModal={mockHandleOpenModal}
+				formatStyle={mockFormatStyle}
+				formatDate={mockFormatDate}
+				truncateResponse={mockTruncateResponse}
+			/>,
+		);
+	};
+
+	// 各テストの前にモック関数をリセット
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("テーブルヘッダーが正しくレンダリングされること", () => {
+		renderComponent();
+
+		expect(screen.getByText("選択")).toBeTruthy();
+		expect(screen.getByText("タイトル")).toBeTruthy();
+		expect(screen.getByText("関連ファイル")).toBeTruthy();
+		expect(screen.getByText("スタイル")).toBeTruthy();
+		expect(screen.getByText("内容")).toBeTruthy();
+		expect(screen.getByText("作成日時")).toBeTruthy();
+	});
+
+	it("すべての出力行がレンダリングされること", () => {
+		renderComponent();
+
+		for (const output of mockOutputs) {
+			// タイトルの確認
+			expect(screen.getByText(output.title)).toBeTruthy();
+
+			// 関連ファイルの確認
+			const fileNames = output.files.map((f) => f.file_name).join(", ");
+			expect(screen.getByText(fileNames)).toBeTruthy();
+
+			// スタイルの確認
+			expect(screen.getByText(`Formatted ${output.style}`)).toBeTruthy();
+
+			// 内容の確認（トランケートされたもの）
+			// getAllByText を使用して複数の要素を取得
+			const truncatedText = `${output.output.slice(0, 10)}...`;
+			const truncatedElements = screen.getAllByText(truncatedText);
+			expect(truncatedElements.length).toBeGreaterThan(0);
+
+			// 作成日時の確認
+			expect(
+				screen.getByText(new Date(output.created_at).toLocaleString()),
+			).toBeTruthy();
+		}
+	});
+
+	it("ラジオボタンの選択が正しく機能すること", () => {
+		renderComponent();
+
+		const radios = screen.getAllByTestId("radio");
+		expect(radios.length).toBe(mockOutputs.length);
+
+		// 最初のラジオボタンを選択
+		fireEvent.click(radios[0]);
+		expect(mockHandleSelect).toHaveBeenCalledWith(mockOutputs[0].id);
+
+		// 2番目のラジオボタンを選択
+		fireEvent.click(radios[1]);
+		expect(mockHandleSelect).toHaveBeenCalledWith(mockOutputs[1].id);
+	});
+
+	it("ヘッダーボタンをクリックするとソートが機能すること", () => {
+		renderComponent();
+
+		const sortableHeaders = [
+			"タイトル",
+			"関連ファイル",
+			"スタイル",
+			"内容",
+			"作成日時",
+		];
+
+		for (const header of sortableHeaders) {
+			// 正規表現を使用してボタン名をマッチ
+			const button = screen.getByRole("button", {
+				name: new RegExp(`^${header} 🔽$`),
+			});
+			fireEvent.click(button);
+			const sortField =
+				header === "タイトル"
+					? "title"
+					: header === "関連ファイル"
+						? "files"
+						: header === "スタイル"
+							? "style"
+							: header === "内容"
+								? "output"
+								: "created_at";
+			expect(mockHandleSort).toHaveBeenCalledWith(sortField);
+		}
+
+		expect(mockHandleSort).toHaveBeenCalledTimes(sortableHeaders.length);
+	});
+
+	it("ソートアイコンが正しく表示されること", () => {
+		renderComponent();
+
+		const sortIcons = screen.getAllByText("🔽");
+		expect(sortIcons.length).toBe(5); // 各ソート可能なカラムに1つずつ
+	});
+
+	it("内容をクリックするとモーダルが開くこと", () => {
+		renderComponent();
+
+		// リテラルの '...' をマッチさせるためにエスケープ
+		const contentButtons = screen.getAllByRole("button", { name: /\.\.\.$/ }); // トランケートされた内容のボタン
+		expect(contentButtons.length).toBe(mockOutputs.length);
+
+		// 最初の内容ボタンをクリック
+		fireEvent.click(contentButtons[0]);
+		expect(mockHandleOpenModal).toHaveBeenCalledWith(mockOutputs[0].output);
+
+		// 2番目の内容ボタンをクリック
+		fireEvent.click(contentButtons[1]);
+		expect(mockHandleOpenModal).toHaveBeenCalledWith(mockOutputs[1].output);
+	});
+
+	it("フォーマット関数が正しく適用されること", () => {
+		renderComponent();
+
+		for (const output of mockOutputs) {
+			expect(mockFormatStyle).toHaveBeenCalledWith(output.style);
+			expect(mockFormatDate).toHaveBeenCalledWith(output.created_at);
+			expect(mockTruncateResponse).toHaveBeenCalledWith(output.output);
+		}
+	});
+
+	it("出力が選択されていない場合のレンダリングが正しいこと", () => {
+		renderComponent(null);
+
+		const radios = screen.getAllByTestId("radio");
+		for (const radio of radios) {
+			expect((radio as HTMLInputElement).checked).toBe(false);
+		}
+	});
+
+	it("特定の出力が選択されている場合のレンダリングが正しいこと", () => {
+		renderComponent(mockOutputs[0].id);
+
+		const radios = screen.getAllByTestId("radio");
+		expect((radios[0] as HTMLInputElement).checked).toBe(true);
+		expect((radios[1] as HTMLInputElement).checked).toBe(false);
+	});
+});

--- a/frontend-nextjs/__tests__/features/dashboard/select-notes/NotesTable.test.tsx
+++ b/frontend-nextjs/__tests__/features/dashboard/select-notes/NotesTable.test.tsx
@@ -1,0 +1,195 @@
+import NotesTable from "@/features/dashboard/select-notes/NotesTable";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// @material-tailwind/react コンポーネントのモック
+vi.mock("@material-tailwind/react", () => ({
+	Radio: ({
+		checked,
+		onChange,
+	}: {
+		checked: boolean;
+		onChange: () => void;
+	}) => (
+		<input
+			type="radio"
+			checked={checked}
+			onChange={onChange}
+			data-testid="radio"
+		/>
+	),
+	Typography: ({ children }: { children: React.ReactNode }) => (
+		<span>{children}</span>
+	),
+}));
+
+describe("NotesTable コンポーネント", () => {
+	// テスト用のノートデータ
+	const mockNotes = [
+		{
+			id: 1,
+			title: "First Note",
+			content: "This is the first note content.",
+			user_id: "user1",
+			updated_at: "2023-10-01T10:00:00Z",
+		},
+		{
+			id: 2,
+			title: "Second Note",
+			content: "This is the second note content.",
+			user_id: "user2",
+			updated_at: "2023-10-02T12:00:00Z",
+		},
+	];
+
+	// モック関数の定義
+	const mockHandleSelect = vi.fn();
+	const mockGetSortIcon = vi.fn().mockReturnValue("🔽");
+	const mockHandleSort = vi.fn();
+	const mockHandleOpenModal = vi.fn();
+	const mockFormatDate = vi
+		.fn()
+		.mockImplementation((dateStr: string) =>
+			new Date(dateStr).toLocaleString(),
+		);
+	const mockTruncateContent = vi
+		.fn()
+		.mockImplementation((str: string) => `${str.slice(0, 10)}...`);
+
+	// コンポーネントをレンダリングするヘルパー関数
+	const renderComponent = (selectedNoteId: number | null = null) => {
+		render(
+			<NotesTable
+				notes={mockNotes}
+				selectedNoteId={selectedNoteId}
+				handleSelect={mockHandleSelect}
+				handleOpenModal={mockHandleOpenModal}
+				getSortIcon={mockGetSortIcon}
+				handleSort={mockHandleSort}
+				formatDate={mockFormatDate}
+				truncateContent={mockTruncateContent}
+			/>,
+		);
+	};
+
+	// 各テストの前にモック関数をリセット
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("テーブルヘッダーが正しくレンダリングされること", () => {
+		renderComponent();
+
+		expect(screen.getByText("選択")).toBeTruthy();
+		expect(screen.getByText("タイトル")).toBeTruthy();
+		expect(screen.getByText("内容")).toBeTruthy();
+		expect(screen.getByText("更新日時")).toBeTruthy();
+	});
+
+	it("すべてのノート行がレンダリングされること", () => {
+		renderComponent();
+
+		for (const note of mockNotes) {
+			// タイトルの確認
+			expect(screen.getByText(note.title)).toBeTruthy();
+
+			// 内容の確認（トランケートされたもの）
+			const truncatedContent = `${note.content.slice(0, 10)}...`;
+			const truncatedElements = screen.getAllByText(truncatedContent);
+			expect(truncatedElements.length).toBeGreaterThan(0);
+
+			// 更新日時の確認
+			expect(
+				screen.getByText(new Date(note.updated_at).toLocaleString()),
+			).toBeTruthy();
+		}
+	});
+
+	it("ラジオボタンの選択が正しく機能すること", () => {
+		renderComponent();
+
+		const radios = screen.getAllByTestId("radio");
+		expect(radios.length).toBe(mockNotes.length);
+
+		// 最初のラジオボタンを選択
+		fireEvent.click(radios[0]);
+		expect(mockHandleSelect).toHaveBeenCalledWith(mockNotes[0].id);
+
+		// 2番目のラジオボタンを選択
+		fireEvent.click(radios[1]);
+		expect(mockHandleSelect).toHaveBeenCalledWith(mockNotes[1].id);
+	});
+
+	it("ヘッダーボタンをクリックするとソートが機能すること", () => {
+		renderComponent();
+
+		const sortableHeaders = ["タイトル", "内容", "更新日時"];
+
+		for (const header of sortableHeaders) {
+			// 正規表現を使用してボタン名をマッチ
+			const button = screen.getByRole("button", {
+				name: new RegExp(`^${header} 🔽$`),
+			});
+			fireEvent.click(button);
+			const sortField =
+				header === "タイトル"
+					? "title"
+					: header === "内容"
+						? "content"
+						: "updated_at";
+			expect(mockHandleSort).toHaveBeenCalledWith(sortField);
+		}
+
+		expect(mockHandleSort).toHaveBeenCalledTimes(sortableHeaders.length);
+	});
+
+	it("ソートアイコンが正しく表示されること", () => {
+		renderComponent();
+
+		const sortIcons = screen.getAllByText("🔽");
+		expect(sortIcons.length).toBe(3); // 各ソート可能なカラムに1つずつ
+	});
+
+	it("内容をクリックするとモーダルが開くこと", () => {
+		renderComponent();
+
+		// リテラルの '...' をマッチさせるためにエスケープ
+		const contentButtons = screen.getAllByRole("button", { name: /\.\.\.$/ }); // トランケートされた内容のボタン
+		expect(contentButtons.length).toBe(mockNotes.length);
+
+		// 最初の内容ボタンをクリック
+		fireEvent.click(contentButtons[0]);
+		expect(mockHandleOpenModal).toHaveBeenCalledWith(mockNotes[0].content);
+
+		// 2番目の内容ボタンをクリック
+		fireEvent.click(contentButtons[1]);
+		expect(mockHandleOpenModal).toHaveBeenCalledWith(mockNotes[1].content);
+	});
+
+	it("フォーマット関数が正しく適用されること", () => {
+		renderComponent();
+
+		for (const note of mockNotes) {
+			expect(mockFormatDate).toHaveBeenCalledWith(note.updated_at);
+			expect(mockTruncateContent).toHaveBeenCalledWith(note.content);
+		}
+	});
+
+	it("ノートが選択されていない場合のレンダリングが正しいこと", () => {
+		renderComponent(null);
+
+		const radios = screen.getAllByTestId("radio");
+		for (const radio of radios) {
+			expect((radio as HTMLInputElement).checked).toBe(false);
+		}
+	});
+
+	it("特定のノートが選択されている場合のレンダリングが正しいこと", () => {
+		renderComponent(mockNotes[0].id);
+
+		const radios = screen.getAllByTestId("radio");
+		expect((radios[0] as HTMLInputElement).checked).toBe(true);
+		expect((radios[1] as HTMLInputElement).checked).toBe(false);
+	});
+});

--- a/frontend-nextjs/__tests__/features/dashboard/select-notes/SelectNotes.test.tsx
+++ b/frontend-nextjs/__tests__/features/dashboard/select-notes/SelectNotes.test.tsx
@@ -200,32 +200,22 @@ describe("SelectNotesComponent", () => {
 			expect(screen.getByText("テストノート1")).toBeInTheDocument();
 		});
 
-		// モーダルを開くために内容のセルをクリック
-		const contentCells = screen.getAllByText("テスト内容1");
-		const tableCell = contentCells.find(
-			(element) => element.classList.contains("max-w-xs"), // テーブルセル内のテキストを特定
-		);
-		expect(tableCell).toBeInTheDocument();
-
-		const contentButton = tableCell?.closest("button");
+		// モーダルを開くために内容のセル内のボタンを取得
+		const contentButton = screen.getByRole("button", { name: /テスト内容1/i });
 		expect(contentButton).toBeInTheDocument();
 
 		await act(async () => {
-			if (contentButton) {
-				fireEvent.click(contentButton);
-			} else {
-				throw new Error("Content button not found");
-			}
+			fireEvent.click(contentButton);
 		});
 
 		// モーダルの表示を確認
 		await waitFor(() => {
-			expect(screen.getByText("ノートの内容")).toBeInTheDocument();
-			// モーダル内のテキストを特定
-			const modalContent = screen.getAllByText("テスト内容1").find(
-				(element) => element.classList.contains("text-base"), // モーダル内のテキストを特定
-			);
-			expect(modalContent).toBeInTheDocument();
+			const dialog = screen.getByRole("dialog");
+			expect(dialog).toBeInTheDocument();
+
+			// モーダル内でテキストを確認
+			expect(within(dialog).getByText("ノートの内容")).toBeInTheDocument();
+			expect(within(dialog).getByText("テスト内容1")).toBeInTheDocument();
 		});
 	});
 

--- a/frontend-nextjs/src/features/dashboard/ai-exercise/select-answers/AnswersTable.tsx
+++ b/frontend-nextjs/src/features/dashboard/ai-exercise/select-answers/AnswersTable.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import type { AnswerResponse } from "@/features/dashboard/ai-exercise/select-answers/useFetchAnswers";
+import { Checkbox, Typography } from "@material-tailwind/react";
+
+interface AnswersTableProps {
+	answers: AnswerResponse[];
+	selectedAnswerIds: number[];
+	handleSelect: (id: number) => void;
+	handleSelectAll: () => void;
+	isAllSelected: boolean;
+	handleSort: (field: keyof AnswerResponse) => void;
+	getSortIcon: (field: keyof AnswerResponse) => string;
+	truncateContent: (str: string, maxLength?: number) => string;
+	handleOpenModal: (answer: AnswerResponse) => void;
+}
+
+export const AnswersTable: React.FC<AnswersTableProps> = ({
+	answers,
+	selectedAnswerIds,
+	handleSelect,
+	handleSelectAll,
+	isAllSelected,
+	handleSort,
+	getSortIcon,
+	truncateContent,
+	handleOpenModal,
+}) => {
+	return (
+		<div className="overflow-hidden">
+			<table className="w-full min-w-full table-fixed text-left">
+				<thead>
+					<tr>
+						<th className="border-b p-4 w-12">
+							<Checkbox
+								checked={isAllSelected}
+								onChange={handleSelectAll}
+								aria-label="全選択"
+							/>
+						</th>
+						<th className="border-b p-4 w-1/6">
+							<button
+								type="button"
+								onClick={() => handleSort("title")}
+								className="flex items-center gap-1 hover:bg-gray-50 px-2 py-1 rounded w-full text-left"
+							>
+								<Typography
+									variant="small"
+									className="font-normal leading-none"
+								>
+									タイトル
+								</Typography>
+								<span>{getSortIcon("title")}</span>
+							</button>
+						</th>
+						<th className="border-b p-4 w-1/4">
+							<button
+								type="button"
+								onClick={() => handleSort("question_text")}
+								className="flex items-center gap-1 hover:bg-gray-50 px-2 py-1 rounded w-full text-left"
+							>
+								<Typography
+									variant="small"
+									className="font-normal leading-none"
+								>
+									質問文
+								</Typography>
+								<span>{getSortIcon("question_text")}</span>
+							</button>
+						</th>
+						<th className="border-b p-4 w-1/4">選択肢</th>
+						<th className="border-b p-4 w-1/12">
+							<button
+								type="button"
+								onClick={() => handleSort("is_correct")}
+								className="flex items-center gap-1 hover:bg-gray-50 px-2 py-1 rounded w-full text-left"
+							>
+								<Typography
+									variant="small"
+									className="font-normal leading-none"
+								>
+									正誤
+								</Typography>
+								<span>{getSortIcon("is_correct")}</span>
+							</button>
+						</th>
+						<th className="border-b p-4 w-1/6">
+							<button
+								type="button"
+								onClick={() => handleSort("updated_at")}
+								className="flex items-center gap-1 hover:bg-gray-50 px-2 py-1 rounded w-full text-left"
+							>
+								<Typography
+									variant="small"
+									className="font-normal leading-none"
+								>
+									更新日時
+								</Typography>
+								<span>{getSortIcon("updated_at")}</span>
+							</button>
+						</th>
+					</tr>
+				</thead>
+				<tbody>
+					{answers.map((answer) => (
+						<tr key={answer.id} className="hover:bg-gray-100">
+							<td className="p-4 w-12">
+								<Checkbox
+									name={`answer-select-${answer.id}`}
+									checked={selectedAnswerIds.includes(answer.id)}
+									onChange={(e) => {
+										e.stopPropagation();
+										handleSelect(answer.id);
+									}}
+									aria-label={`選択 ${answer.title}`}
+								/>
+							</td>
+							<td className="p-4 w-1/6">
+								<Typography
+									variant="small"
+									className="font-normal break-words text-xs whitespace-normal"
+								>
+									{answer.title}
+								</Typography>
+							</td>
+							<td className="p-4 w-1/4">
+								{/* 質問文をクリック可能にする */}
+								<button
+									type="button"
+									onClick={(e) => {
+										e.stopPropagation(); // 他のイベントの発火を防ぐ
+										handleOpenModal(answer);
+									}}
+									onKeyDown={(e) => {
+										if (e.key === "Enter" || e.key === " ") {
+											e.preventDefault();
+											handleOpenModal(answer);
+										}
+									}}
+									className="w-full text-left focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
+									aria-label={`質問文を開く: ${answer.question_text}`}
+								>
+									<Typography
+										variant="small"
+										className="font-normal whitespace-normal text-xs hover:underline"
+									>
+										{truncateContent(answer.question_text, 100)}
+									</Typography>
+								</button>
+							</td>
+							<td className="p-4 w-1/4">
+								<Typography
+									variant="small"
+									className="font-normal break-words text-xs whitespace-normal"
+								>
+									A: {answer.choice_a} <br />
+									B: {answer.choice_b} <br />
+									C: {answer.choice_c} <br />
+									D: {answer.choice_d}
+								</Typography>
+							</td>
+							<td className="p-4 w-1/12">
+								<Typography
+									variant="small"
+									className={`font-normal text-xs ${
+										answer.is_correct ? "text-green-600" : "text-red-600"
+									} whitespace-normal`}
+								>
+									{answer.is_correct ? "正解" : "不正解"}
+								</Typography>
+							</td>
+							<td className="p-4 w-1/6">
+								<Typography
+									variant="small"
+									className="font-normal text-xs whitespace-normal"
+								>
+									{new Date(answer.updated_at).toLocaleString()}
+								</Typography>
+							</td>
+						</tr>
+					))}
+				</tbody>
+			</table>
+		</div>
+	);
+};

--- a/frontend-nextjs/src/features/dashboard/ai-exercise/select-answers/SelectAnswers.tsx
+++ b/frontend-nextjs/src/features/dashboard/ai-exercise/select-answers/SelectAnswers.tsx
@@ -22,6 +22,7 @@ import {
 } from "@material-tailwind/react";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { AnswersTable } from "./AnswersTable"; // AnswersTableコンポーネントをインポート
 
 // クリアすべきローカルストレージキーの定義
 const STORAGE_KEYS_TO_CLEAR = [
@@ -362,161 +363,18 @@ export default function SelectAnswers() {
 						<Alert variant="gradient">解答が見つかりません</Alert>
 					) : (
 						<>
-							<table className="w-full min-w-max table-auto text-left">
-								<thead>
-									<tr>
-										<th className="border-b p-4">
-											<Checkbox
-												checked={isAllSelected}
-												onChange={handleSelectAll}
-												aria-label="全選択"
-											/>
-										</th>
-										<th className="border-b p-4">
-											<button
-												type="button"
-												onClick={() => handleSort("title")}
-												className="flex items-center gap-1 hover:bg-gray-50 px-2 py-1 rounded"
-											>
-												<Typography
-													variant="small"
-													className="font-normal leading-none"
-												>
-													タイトル
-												</Typography>
-												<span>{getSortIcon("title")}</span>
-											</button>
-										</th>
-										<th className="border-b p-4">
-											<button
-												type="button"
-												onClick={() => handleSort("question_text")}
-												className="flex items-center gap-1 hover:bg-gray-50 px-2 py-1 rounded"
-											>
-												<Typography
-													variant="small"
-													className="font-normal leading-none"
-												>
-													質問文
-												</Typography>
-												<span>{getSortIcon("question_text")}</span>
-											</button>
-										</th>
-										<th className="border-b p-4">選択肢</th>
-										<th className="border-b p-4">
-											<button
-												type="button"
-												onClick={() => handleSort("is_correct")}
-												className="flex items-center gap-1 hover:bg-gray-50 px-2 py-1 rounded"
-											>
-												<Typography
-													variant="small"
-													className="font-normal leading-none"
-												>
-													正誤
-												</Typography>
-												<span>{getSortIcon("is_correct")}</span>
-											</button>
-										</th>
-										<th className="border-b p-4">
-											<button
-												type="button"
-												onClick={() => handleSort("updated_at")}
-												className="flex items-center gap-1 hover:bg-gray-50 px-2 py-1 rounded"
-											>
-												<Typography
-													variant="small"
-													className="font-normal leading-none"
-												>
-													更新日時
-												</Typography>
-												<span>{getSortIcon("updated_at")}</span>
-											</button>
-										</th>
-									</tr>
-								</thead>
-								<tbody>
-									{filteredAndSortedAnswers.map((answer) => (
-										<tr key={answer.id} className="hover:bg-gray-100">
-											<td className="p-4">
-												<Checkbox
-													name={`answer-select-${answer.id}`}
-													checked={selectedAnswerIds.includes(answer.id)}
-													onChange={(e) => {
-														e.stopPropagation();
-														handleSelect(answer.id);
-													}}
-													aria-label={`選択 ${answer.title}`}
-												/>
-											</td>
-											<td className="p-4 max-w-[200px]">
-												<Typography
-													variant="small"
-													className="font-normal break-words text-xs"
-												>
-													{answer.title}
-												</Typography>
-											</td>
-											<td className="p-4 max-w-[300px]">
-												{/* 質問文をクリック可能にする */}
-												<button
-													type="button"
-													onClick={(e) => {
-														e.stopPropagation(); // 他のイベントの発火を防ぐ
-														handleOpenModal(answer);
-													}}
-													onKeyDown={(e) => {
-														if (e.key === "Enter" || e.key === " ") {
-															e.preventDefault();
-															handleOpenModal(answer);
-														}
-													}}
-													className="w-full text-left focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
-													aria-label={`質問文を開く: ${answer.question_text}`}
-												>
-													<Typography
-														variant="small"
-														className="font-normal max-w-xs whitespace-pre-wrap text-xs hover:underline"
-													>
-														{truncateContent(answer.question_text, 100)}
-													</Typography>
-												</button>
-											</td>
-											<td className="p-4 max-w-[300px]">
-												<Typography
-													variant="small"
-													className="font-normal break-words text-xs"
-												>
-													A: {answer.choice_a} <br />
-													B: {answer.choice_b} <br />
-													C: {answer.choice_c} <br />
-													D: {answer.choice_d}
-												</Typography>
-											</td>
-											<td className="p-4">
-												<Typography
-													variant="small"
-													className={`font-normal text-xs ${
-														answer.is_correct
-															? "text-green-600"
-															: "text-red-600"
-													}`}
-												>
-													{answer.is_correct ? "正解" : "不正解"}
-												</Typography>
-											</td>
-											<td className="p-4">
-												<Typography
-													variant="small"
-													className="font-normal text-xs"
-												>
-													{formatDate(answer.updated_at)}
-												</Typography>
-											</td>
-										</tr>
-									))}
-								</tbody>
-							</table>
+							{/* AnswersTableコンポーネントを使用 */}
+							<AnswersTable
+								answers={filteredAndSortedAnswers}
+								selectedAnswerIds={selectedAnswerIds}
+								handleSelect={handleSelect}
+								handleSelectAll={handleSelectAll}
+								isAllSelected={isAllSelected}
+								handleSort={handleSort}
+								getSortIcon={getSortIcon}
+								truncateContent={truncateContent}
+								handleOpenModal={handleOpenModal}
+							/>
 
 							{/* ▼ ページネーション UI */}
 							<div className="mt-4 flex flex-wrap items-center justify-between gap-4">

--- a/frontend-nextjs/src/features/dashboard/ai-exercise/select-exercises/SelectExercises.tsx
+++ b/frontend-nextjs/src/features/dashboard/ai-exercise/select-exercises/SelectExercises.tsx
@@ -366,7 +366,7 @@ export default function ExerciseSelectComponent() {
 						<table className="w-full table-auto">
 							<thead>
 								<tr>
-									<th className="border-b p-4">Select</th>
+									<th className="border-b p-4">選択</th>
 									<th className="border-b p-4">
 										<button
 											type="button"

--- a/frontend-nextjs/src/features/dashboard/ai-output/select-ai-output/OutputTable.tsx
+++ b/frontend-nextjs/src/features/dashboard/ai-output/select-ai-output/OutputTable.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { Radio, Typography } from "@material-tailwind/react";
+
+// ファイルに関する型定義
+interface File {
+	id: string;
+	file_name: string;
+	file_size: string;
+	created_at: string;
+	user_id: string;
+}
+
+// 出力に関する型定義
+interface Output {
+	id: number;
+	title: string;
+	output: string;
+	user_id: string;
+	created_at: string;
+	files: File[];
+	style: string; // 新しいプロパティを追加
+}
+
+type SortField = "created_at" | "output" | "files" | "title" | "style";
+type SortDirection = "asc" | "desc";
+
+interface OutputTableProps {
+	outputs: Output[];
+	selectedOutputId: number | null;
+	handleSelect: (id: number) => void;
+	getSortIcon: (field: SortField) => string;
+	handleSort: (field: SortField) => void;
+	handleOpenModal: (content: string) => void;
+	formatStyle: (style: string | null) => string;
+	formatDate: (dateStr: string) => string;
+	truncateResponse: (str: string) => string;
+}
+
+const OutputTable: React.FC<OutputTableProps> = ({
+	outputs,
+	selectedOutputId,
+	handleSelect,
+	getSortIcon,
+	handleSort,
+	handleOpenModal,
+	formatStyle,
+	formatDate,
+	truncateResponse,
+}) => {
+	return (
+		<table className="w-full table-auto text-left">
+			<thead className="hidden md:table-header-group">
+				<tr>
+					<th className="border-b p-4">選択</th>
+					<th className="border-b p-4">
+						<button
+							type="button"
+							onClick={() => handleSort("title")}
+							className="flex items-center gap-1 hover:bg-gray-50 px-2 py-1 rounded"
+						>
+							<Typography variant="small" className="font-normal leading-none">
+								タイトル
+							</Typography>
+							<span>{getSortIcon("title")}</span>
+						</button>
+					</th>
+					<th className="border-b p-4">
+						<button
+							type="button"
+							onClick={() => handleSort("files")}
+							className="flex items-center gap-1 hover:bg-gray-50 px-2 py-1 rounded"
+						>
+							<Typography variant="small" className="font-normal leading-none">
+								関連ファイル
+							</Typography>
+							<span>{getSortIcon("files")}</span>
+						</button>
+					</th>
+					<th className="border-b p-4">
+						<button
+							type="button"
+							onClick={() => handleSort("style")}
+							className="flex items-center gap-1 hover:bg-gray-50 px-2 py-1 rounded"
+						>
+							<Typography variant="small" className="font-normal leading-none">
+								スタイル
+							</Typography>
+							<span>{getSortIcon("style")}</span>
+						</button>
+					</th>
+					<th className="border-b p-4">
+						<button
+							type="button"
+							onClick={() => handleSort("output")}
+							className="flex items-center gap-1 hover:bg-gray-50 px-2 py-1 rounded"
+						>
+							<Typography variant="small" className="font-normal leading-none">
+								内容
+							</Typography>
+							<span>{getSortIcon("output")}</span>
+						</button>
+					</th>
+					<th className="border-b p-4">
+						<button
+							type="button"
+							onClick={() => handleSort("created_at")}
+							className="flex items-center gap-1 hover:bg-gray-50 px-2 py-1 rounded"
+						>
+							<Typography variant="small" className="font-normal leading-none">
+								作成日時
+							</Typography>
+							<span>{getSortIcon("created_at")}</span>
+						</button>
+					</th>
+				</tr>
+			</thead>
+			<tbody>
+				{outputs.map((output) => (
+					<tr key={output.id} className="md:table-row block md:static">
+						{/* 選択 */}
+						<td className="p-4 border-b md:border-none block md:table-cell">
+							<span className="inline-block md:hidden font-semibold mr-2">
+								選択:
+							</span>
+							<Radio
+								name="output-select"
+								checked={selectedOutputId === output.id}
+								onChange={() => handleSelect(output.id)}
+							/>
+						</td>
+						{/* タイトル */}
+						<td className="p-4 border-b md:border-none block md:table-cell">
+							<span className="inline-block md:hidden font-semibold mr-2">
+								タイトル:
+							</span>
+							<Typography
+								variant="small"
+								className="font-normal break-words text-xs"
+							>
+								{output.title}
+							</Typography>
+						</td>
+						{/* 関連ファイル */}
+						<td className="p-4 border-b md:border-none block md:table-cell">
+							<span className="inline-block md:hidden font-semibold mr-2">
+								関連ファイル:
+							</span>
+							<Typography
+								variant="small"
+								className="font-normal break-words text-xs"
+							>
+								{output.files.map((file) => file.file_name).join(", ")}
+							</Typography>
+						</td>
+						{/* スタイル */}
+						<td className="p-4 border-b md:border-none block md:table-cell">
+							<span className="inline-block md:hidden font-semibold mr-2">
+								スタイル:
+							</span>
+							<Typography variant="small" className="font-normal text-xs">
+								{formatStyle(output.style)}
+							</Typography>
+						</td>
+						{/* 内容 */}
+						<td className="p-4 border-b md:border-none block md:table-cell">
+							<span className="inline-block md:hidden font-semibold mr-2">
+								内容:
+							</span>
+							<button
+								type="button"
+								className="w-full text-left cursor-pointer hover:bg-gray-50"
+								onClick={() => handleOpenModal(output.output)}
+							>
+								<Typography
+									variant="small"
+									className="font-normal max-w-full whitespace-pre-wrap text-xs break-words"
+								>
+									{truncateResponse(output.output)}
+								</Typography>
+							</button>
+						</td>
+						{/* 作成日時 */}
+						<td className="p-4 border-b md:border-none block md:table-cell">
+							<span className="inline-block md:hidden font-semibold mr-2">
+								作成日時:
+							</span>
+							<Typography variant="small" className="font-normal text-xs">
+								{formatDate(output.created_at)}
+							</Typography>
+						</td>
+					</tr>
+				))}
+			</tbody>
+		</table>
+	);
+};
+
+export default OutputTable;

--- a/frontend-nextjs/src/features/dashboard/select-notes/NotesTable.tsx
+++ b/frontend-nextjs/src/features/dashboard/select-notes/NotesTable.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { Radio, Typography } from "@material-tailwind/react";
+import type React from "react";
+
+interface Note {
+	id: number;
+	title: string;
+	content: string;
+	user_id: string;
+	updated_at: string;
+}
+
+type SortField = "updated_at" | "content" | "title";
+type SortDirection = "asc" | "desc";
+
+interface NotesTableProps {
+	notes: Note[];
+	selectedNoteId: number | null;
+	handleSelect: (id: number) => void;
+	handleOpenModal: (content: string) => void;
+	getSortIcon: (field: SortField) => string;
+	handleSort: (field: SortField) => void;
+	formatDate: (dateStr: string) => string;
+	truncateContent: (str: string) => string;
+}
+
+const NotesTable: React.FC<NotesTableProps> = ({
+	notes,
+	selectedNoteId,
+	handleSelect,
+	handleOpenModal,
+	getSortIcon,
+	handleSort,
+	formatDate,
+	truncateContent,
+}) => {
+	return (
+		<div className="overflow-x-auto">
+			<table className="w-full table-fixed text-left">
+				<thead>
+					<tr>
+						<th className="border-b p-4 w-1/12">選択</th>
+						<th className="border-b p-4 w-3/12">
+							<button
+								type="button"
+								onClick={() => handleSort("title")}
+								className="flex items-center gap-1 hover:bg-gray-50 px-2 py-1 rounded w-full text-left"
+							>
+								<Typography
+									variant="small"
+									className="font-normal leading-none"
+								>
+									タイトル
+								</Typography>
+								<span>{getSortIcon("title")}</span>
+							</button>
+						</th>
+						<th className="border-b p-4 w-5/12">
+							<button
+								type="button"
+								onClick={() => handleSort("content")}
+								className="flex items-center gap-1 hover:bg-gray-50 px-2 py-1 rounded w-full text-left"
+							>
+								<Typography
+									variant="small"
+									className="font-normal leading-none"
+								>
+									内容
+								</Typography>
+								<span>{getSortIcon("content")}</span>
+							</button>
+						</th>
+						<th className="border-b p-4 w-3/12">
+							<button
+								type="button"
+								onClick={() => handleSort("updated_at")}
+								className="flex items-center gap-1 hover:bg-gray-50 px-2 py-1 rounded w-full text-left"
+							>
+								<Typography
+									variant="small"
+									className="font-normal leading-none"
+								>
+									更新日時
+								</Typography>
+								<span>{getSortIcon("updated_at")}</span>
+							</button>
+						</th>
+					</tr>
+				</thead>
+				<tbody>
+					{notes.map((note) => (
+						<tr key={note.id}>
+							<td className="p-4">
+								<Radio
+									name="note-select"
+									checked={selectedNoteId === note.id}
+									onChange={() => handleSelect(note.id)}
+								/>
+							</td>
+							<td className="p-4">
+								<Typography
+									variant="small"
+									className="font-normal break-words text-xs whitespace-normal"
+								>
+									{note.title}
+								</Typography>
+							</td>
+							<td className="p-4">
+								<button
+									type="button"
+									className="w-full text-left cursor-pointer hover:bg-gray-50"
+									onClick={() => handleOpenModal(note.content)}
+								>
+									<Typography
+										variant="small"
+										className="font-normal max-w-full whitespace-normal break-words text-xs"
+									>
+										{truncateContent(note.content)}
+									</Typography>
+								</button>
+							</td>
+							<td className="p-4">
+								<Typography
+									variant="small"
+									className="font-normal text-xs whitespace-normal"
+								>
+									{formatDate(note.updated_at)}
+								</Typography>
+							</td>
+						</tr>
+					))}
+				</tbody>
+			</table>
+		</div>
+	);
+};
+
+export default NotesTable;

--- a/frontend-nextjs/src/features/dashboard/select-notes/SelectNotes.tsx
+++ b/frontend-nextjs/src/features/dashboard/select-notes/SelectNotes.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { PopupDialog } from "@/components/elements/PopupDialog";
+import NotesTable from "@/features/dashboard/select-notes/NotesTable";
 import { useNoteDelete } from "@/features/dashboard/select-notes/useNoteDelete";
 import { useAuthFetch } from "@/hooks/useAuthFetch";
 import { useAuth } from "@/providers/AuthProvider";
@@ -236,101 +237,16 @@ export default function SelectNotesComponent() {
 					) : !notes.length ? (
 						<Alert variant="gradient">ノートが見つかりません</Alert>
 					) : (
-						<table className="w-full min-w-max table-auto text-left">
-							<thead>
-								<tr>
-									<th className="border-b p-4">Select</th>
-									<th className="border-b p-4">
-										<button
-											type="button"
-											onClick={() => handleSort("title")}
-											className="flex items-center gap-1 hover:bg-gray-50 px-2 py-1 rounded"
-										>
-											<Typography
-												variant="small"
-												className="font-normal leading-none"
-											>
-												タイトル
-											</Typography>
-											<span>{getSortIcon("title")}</span>
-										</button>
-									</th>
-									<th className="border-b p-4">
-										<button
-											type="button"
-											onClick={() => handleSort("content")}
-											className="flex items-center gap-1 hover:bg-gray-50 px-2 py-1 rounded"
-										>
-											<Typography
-												variant="small"
-												className="font-normal leading-none"
-											>
-												内容
-											</Typography>
-											<span>{getSortIcon("content")}</span>
-										</button>
-									</th>
-									<th className="border-b p-4">
-										<button
-											type="button"
-											onClick={() => handleSort("updated_at")}
-											className="flex items-center gap-1 hover:bg-gray-50 px-2 py-1 rounded"
-										>
-											<Typography
-												variant="small"
-												className="font-normal leading-none"
-											>
-												更新日時
-											</Typography>
-											<span>{getSortIcon("updated_at")}</span>
-										</button>
-									</th>
-								</tr>
-							</thead>
-							<tbody>
-								{filteredAndSortedNotes.map((note) => (
-									<tr key={note.id}>
-										<td className="p-4">
-											<Radio
-												name="note-select"
-												checked={selectedNoteId === note.id}
-												onChange={() => handleSelect(note.id)}
-											/>
-										</td>
-										<td className="p-4">
-											<Typography
-												variant="small"
-												className="font-normal break-words text-xs"
-											>
-												{note.title}
-											</Typography>
-										</td>
-										<td className="p-4">
-											<button
-												type="button"
-												className="w-full text-left cursor-pointer hover:bg-gray-50"
-												onClick={() => handleOpenModal(note.content)}
-											>
-												<Typography
-													variant="small"
-													className="font-normal max-w-xs whitespace-pre-wrap text-xs"
-												>
-													{truncateContent(note.content)}
-												</Typography>
-											</button>
-										</td>
-										<td className="p-4">
-											<Typography
-												variant="small"
-												className="font-normal text-xs"
-											>
-												{formatDate(note.updated_at)}
-											</Typography>
-										</td>
-									</tr>
-								))}
-							</tbody>
-						</table>
+						<NotesTable
+							notes={filteredAndSortedNotes}
+							selectedNoteId={selectedNoteId}
+							handleSelect={handleSelect}
+							handleOpenModal={handleOpenModal}
+							getSortIcon={getSortIcon}
+							handleSort={handleSort}
+							formatDate={formatDate}
+							truncateContent={truncateContent}
+						/>
 					)}
 				</CardBody>
 			</Card>


### PR DESCRIPTION
## Issue No.
<!-- 対応しているissue番号を貼る。 -->
<!-- resolve <issue番号>としてください (resolveは残す) -->

resolve 

## 影響範囲とその理由
<!-- この変更により起こり得る影響範囲とその理由を書いてください。 -->
ウィンドウの横幅を狭くすると、テーブルの幅が狭くなります。

## チェックリスト
<!-- 変更を行った際にチェックした項目にチェックを入れてください。 -->
- [x] 単体テストを実施した
- [ ] 統合テストを実施した
- [ ] ドキュメントを更新した

## スクリーンショット
<!-- UIの変更がある場合は、Before / Afterのスクリーンショットや動作が分かるGIFなどを添付してください。 -->
◎修正前
<img width="1470" alt="スクリーンショット 2025-01-25 19 25 57" src="https://github.com/user-attachments/assets/2f4f5713-c3a2-4f40-b007-be08fe709cfa" />
<img width="1470" alt="スクリーンショット 2025-01-25 19 28 31" src="https://github.com/user-attachments/assets/fc842b6b-9500-4d25-afbb-e4bd80d37a1c" />
<img width="1469" alt="スクリーンショット 2025-01-25 19 29 04" src="https://github.com/user-attachments/assets/ff09c00a-f856-46cb-add1-792ed84cb38b" />
◎修正後
<img width="1470" alt="スクリーンショット 2025-01-25 19 32 27" src="https://github.com/user-attachments/assets/7a971384-32a5-4d66-8d89-c6ee6eeca1b6" />

<img width="1464" alt="スクリーンショット 2025-01-25 19 33 14" src="https://github.com/user-attachments/assets/b9f0ac02-88b7-4abb-8f8f-20df14350589" />
<img width="1464" alt="スクリーンショット 2025-01-25 19 33 31" src="https://github.com/user-attachments/assets/de9167f8-73a0-40a0-a626-ba66bd769f1b" />

## レビュアーに確認してほしいこと 
<!-- テストや事象の再現が必要な場合、レビュアーが再現できる実施手順を必ず明記してください！ -->
<!-- レビュワーに特に注目してほしいポイントや、不安な部分があれば明記してください。 -->
◎「AI要約リスト」「解答リスト」「ノートリスト」を表示して、ウィンドウ幅を狭くすると、テーブルが欠けることなく幅が縮まることを確認して欲しいです。

## 関連リンク
<!-- ソースコードに関連するファイルがあればリンクを共有 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- AI出力、ノート、回答の選択と表示のための新しいテーブルコンポーネントを追加
	- 出力、ノート、回答のソート、選択、モーダル表示機能を強化

- **バグ修正**
	- テーブルのレンダリングと対話性を改善

- **リファクタリング**
	- コンポーネントの構造を最適化し、モジュール性を向上
	- 日本語ローカライゼーションを追加

- **テスト**
	- 新しいテーブルコンポーネントの包括的なテストスイートを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->