### PR TITLE
ノートテーブルの時刻を日本時刻に変更

### DIFF
--- a/backend/app/cruds/notes.py
+++ b/backend/app/cruds/notes.py
@@ -13,11 +13,10 @@ JST = timezone(timedelta(hours=9))
 
 
 async def create_note(db: AsyncSession, note_create: notes_schemas.NoteCreate) -> notes_models.Note:
-    note = notes_models.Note(**note_create.model_dump())
-    # 日本時間の現在日時を取得
+    note_dict = note_create.model_dump()
     now_japan = datetime.now(JST)
-    note.created_at = now_japan
-    note.updated_at = now_japan
+    note_dict.update({"created_at": now_japan, "updated_at": now_japan})
+    note = notes_models.Note(**note_dict)
     db.add(note)
     await db.commit()
     await db.refresh(note)

--- a/backend/app/cruds/notes.py
+++ b/backend/app/cruds/notes.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta, timezone
 from typing import Optional, Sequence
 
 from sqlalchemy import select
@@ -7,11 +8,16 @@ from sqlalchemy.ext.asyncio import AsyncSession
 import app.models.notes as notes_models
 import app.schemas.notes as notes_schemas
 
+# 日本時間のタイムゾーン
+JST = timezone(timedelta(hours=9))
 
-async def create_note(
-    db: AsyncSession, note_create: notes_schemas.NoteCreate
-) -> notes_models.Note:
+
+async def create_note(db: AsyncSession, note_create: notes_schemas.NoteCreate) -> notes_models.Note:
     note = notes_models.Note(**note_create.model_dump())
+    # 日本時間の現在日時を取得
+    now_japan = datetime.now(JST)
+    note.created_at = now_japan
+    note.updated_at = now_japan
     db.add(note)
     await db.commit()
     await db.refresh(note)
@@ -26,12 +32,8 @@ async def get_note_by_id(db: AsyncSession, note_id: int) -> Optional[notes_model
     return note
 
 
-async def get_notes(
-    db: AsyncSession, offset: int, limit: int
-) -> Sequence[notes_models.Note]:
-    result: Result = await db.execute(
-        select(notes_models.Note).offset(offset).limit(limit)
-    )
+async def get_notes(db: AsyncSession, offset: int, limit: int) -> Sequence[notes_models.Note]:
+    result: Result = await db.execute(select(notes_models.Note).offset(offset).limit(limit))
     notes = result.scalars().all()
     return notes
 
@@ -60,6 +62,11 @@ async def update_note(
 
     for key, value in note_update.model_dump().items():
         setattr(note, key, value)
+
+    # 日本時間の現在日時を取得
+    now_japan = datetime.now(JST)
+    note.updated_at = now_japan
+
     db.add(note)
     await db.commit()
     await db.refresh(note)


### PR DESCRIPTION
## Issue No.
#315
resolve #315

## 影響範囲とその理由
ノートテーブルの時刻をLocalの時刻を参照していたのを日本時刻に変更

## チェックリスト
- [X] 単体テストを実施した
- [ ] 統合テストを実施した
- [ ] ドキュメントを更新した

## スクリーンショット

## レビュアーに確認してほしいこと 
- ノートが正常に作成・更新できること
- バックエンドのテストが通ること
※ 元々Localの時刻を参照していたので、開発環境では問題が再現しない認識です

## 関連リンク


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ノート作成と更新時に日本標準時（JST）のタイムスタンプを自動的に追加
	- `created_at` と `updated_at` フィールドに現在時刻を設定

- **バグ修正**
	- タイムスタンプの処理を改善し、一貫性のあるデータ管理を実現

<!-- end of auto-generated comment: release notes by coderabbit.ai -->